### PR TITLE
Performance improvement for expr slots using Mapping-derived class for bindings

### DIFF
--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -1,8 +1,8 @@
 import json
 import logging
-from dataclasses import dataclass
-from typing import Any, Dict, List, Iterator, Optional, Tuple, Type, Union
 from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import yaml
 from asteval import Interpreter
@@ -10,7 +10,6 @@ from linkml_runtime import SchemaView
 from linkml_runtime.index.object_index import ObjectIndex
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from pydantic import BaseModel
-from collections.abc import Mapping
 
 from linkml_map.datamodel.transformer_model import (
     CollectionType,
@@ -62,7 +61,7 @@ class Bindings(Mapping):
         """
         if source_obj is None:
             source_obj = self.source_obj
-            
+
         if self.object_transformer.object_index:
             if not self.source_obj_typed:
                 source_obj_dyn = dynamic_object(source_obj, self.sv, self.source_type)
@@ -73,7 +72,7 @@ class Bindings(Mapping):
             # (with optionally the identifier key included) will have the same cache key, and so `bless` will
             # incorrectly return the same cached values.
             self.object_transformer.object_index.clear_proxy_object_cache()
-                
+
             ctxt_obj = self.object_transformer.object_index.bless(source_obj_dyn)
             ctxt_dict = {
                 k: getattr(ctxt_obj, k) for k in ctxt_obj._attributes() if not k.startswith("_")
@@ -86,7 +85,7 @@ class Bindings(Mapping):
         self.bindings.update(ctxt_dict)
 
         return ctxt_obj, ctxt_dict
-    
+
     def _all_keys(self) -> List[Any]:
         keys = list(self.source_obj.keys()) + list(self.bindings.keys())
         # Remove duplicate keys (ie. found in both source_obj and bindings), and retain original order
@@ -95,14 +94,14 @@ class Bindings(Mapping):
 
     def __len__(self) -> int:
         return len(self._all_keys())
-    
+
     def __iter__(self) -> Iterator:
         return iter(self._all_keys())
-    
+
     def __getitem__(self, name: Any) -> Any:
         if name not in self.bindings:
             _ = self.get_ctxt_obj_and_dict({name: self.source_obj[name]})
-        
+
         return self.bindings.get(name)
 
     def __setitem__(self, name: Any, value: Any):
@@ -213,7 +212,7 @@ class ObjectTransformer(Transformer):
                         sv=sv,
                         bindings={"NULL": None},
                     )
-                    
+
                 try:
                     v = eval_expr_with_mapping(slot_derivation.expr, bindings)
                 except Exception:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import yaml
 from asteval import Interpreter
@@ -17,13 +18,95 @@ from linkml_map.datamodel.transformer_model import (
 )
 from linkml_map.functions.unit_conversion import UnitSystem, convert_units
 from linkml_map.transformer.transformer import OBJECT_TYPE, Transformer
-from linkml_map.utils.dynamic_object import dynamic_object
-from linkml_map.utils.eval_utils import eval_expr
+from linkml_map.utils.dynamic_object import DynObj, dynamic_object
+from linkml_map.utils.eval_utils import eval_expr, eval_expr_with_mapping
 
 DICT_OBJ = Dict[str, Any]
 
 
 logger = logging.getLogger(__name__)
+
+
+class Bindings(Mapping):
+    """
+    Efficiently access source object attributes.
+    """
+
+    def __init__(
+        self,
+        object_transformer: "ObjectTransformer",
+        source_obj: OBJECT_TYPE,
+        source_obj_typed: OBJECT_TYPE,
+        source_type: str,
+        sv: SchemaView,
+        bindings: Dict,
+    ):
+        self.object_transformer: "ObjectTransformer" = object_transformer
+        self.source_obj: OBJECT_TYPE = source_obj
+        self.source_obj_typed: OBJECT_TYPE = source_obj_typed
+        self.source_type: str = source_type
+        self.sv: SchemaView = sv
+        self.bindings: Dict = {}
+        if bindings:
+            self.bindings.update(bindings)
+
+    def get_ctxt_obj_and_dict(self, source_obj: OBJECT_TYPE = None) -> Tuple[DynObj, OBJECT_TYPE]:
+        """
+        Transform a source object into a typed context object and dictionary, and cache results.
+
+        :param source_obj: Source data. Should be a subset of source_obj provided in the constructor.
+        If None the full source_obj from constructor is used.
+        :return: Tuple of typed context object and context dictionary. The object is the dictionary
+        with keys converted to member variables.
+        """
+        if source_obj is None:
+            source_obj = self.source_obj
+
+        if self.object_transformer.object_index:
+            if not self.source_obj_typed:
+                source_obj_dyn = dynamic_object(source_obj, self.sv, self.source_type)
+            else:
+                source_obj_dyn = self.source_obj_typed
+            # Clear cache: Cache doesn't work since the cache key is the same when source_obj has only a subset
+            # of its keys. eg. {"age": self.source_obj["age"]} and {"name": self.source_obj["name"]}
+            # (with optionally the identifier key included) will have the same cache key, and so `bless` will
+            # incorrectly return the same cached values.
+            self.object_transformer.object_index.clear_proxy_object_cache()
+
+            ctxt_obj = self.object_transformer.object_index.bless(source_obj_dyn)
+            ctxt_dict = {
+                k: getattr(ctxt_obj, k) for k in ctxt_obj._attributes() if not k.startswith("_")
+            }
+        else:
+            do = dynamic_object(source_obj, self.sv, self.source_type)
+            ctxt_obj = do
+            ctxt_dict = vars(do)
+
+        self.bindings.update(ctxt_dict)
+
+        return ctxt_obj, ctxt_dict
+
+    def _all_keys(self) -> List[Any]:
+        keys = list(self.source_obj.keys()) + list(self.bindings.keys())
+        # Remove duplicate keys (ie. found in both source_obj and bindings), and retain original order
+        keys = list(dict.fromkeys(keys).keys())
+        return keys
+
+    def __len__(self) -> int:
+        return len(self._all_keys())
+
+    def __iter__(self) -> Iterator:
+        return iter(self._all_keys())
+
+    def __getitem__(self, name: Any) -> Any:
+        if name not in self.bindings:
+            _ = self.get_ctxt_obj_and_dict({name: self.source_obj[name]})
+
+        return self.bindings.get(name)
+
+    def __setitem__(self, name: Any, value: Any):
+        del name, value
+        raise RuntimeError(f"__setitem__ not allowed on class {self.__class__.__name__}")
 
 
 @dataclass
@@ -112,6 +195,7 @@ class ObjectTransformer(Transformer):
             return source_obj
         class_deriv = self._get_class_derivation(source_type)
         tgt_attrs = {}
+        bindings = None
         # map each slot assignment in source_obj, if there is a slot_derivation
         for slot_derivation in class_deriv.slot_derivations.values():
             v = None
@@ -119,27 +203,22 @@ class ObjectTransformer(Transformer):
             if slot_derivation.unit_conversion:
                 v = self._perform_unit_conversion(slot_derivation, source_obj, sv, source_type)
             elif slot_derivation.expr:
-                if self.object_index:
-                    if not source_obj_typed:
-                        source_obj_dyn = dynamic_object(source_obj, sv, source_type)
-                    else:
-                        source_obj_dyn = source_obj_typed
-                    ctxt_obj = self.object_index.bless(source_obj_dyn)
-                    ctxt_dict = {
-                        k: getattr(ctxt_obj, k)
-                        for k in ctxt_obj._attributes()
-                        if not k.startswith("_")
-                    }
-                else:
-                    do = dynamic_object(source_obj, sv, source_type)
-                    ctxt_obj = do
-                    ctxt_dict = vars(do)
+                if bindings is None:
+                    bindings = Bindings(
+                        self,
+                        source_obj=source_obj,
+                        source_obj_typed=source_obj_typed,
+                        source_type=source_type,
+                        sv=sv,
+                        bindings={"NULL": None},
+                    )
 
                 try:
-                    v = eval_expr(slot_derivation.expr, **ctxt_dict, NULL=None)
+                    v = eval_expr_with_mapping(slot_derivation.expr, bindings)
                 except Exception:
                     if not self.unrestricted_eval:
                         raise RuntimeError(f"Expression not in safe subset: {slot_derivation.expr}")
+                    ctxt_obj, _ = bindings.get_ctxt_obj_and_dict()
                     aeval = Interpreter(usersyms={"src": ctxt_obj, "target": None})
                     aeval(slot_derivation.expr)
                     v = aeval.symtable["target"]

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -1,7 +1,8 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Iterator, Optional, Tuple, Type, Union
+from collections.abc import Mapping
 
 import yaml
 from asteval import Interpreter
@@ -9,6 +10,7 @@ from linkml_runtime import SchemaView
 from linkml_runtime.index.object_index import ObjectIndex
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from pydantic import BaseModel
+from collections.abc import Mapping
 
 from linkml_map.datamodel.transformer_model import (
     CollectionType,
@@ -17,13 +19,95 @@ from linkml_map.datamodel.transformer_model import (
 )
 from linkml_map.functions.unit_conversion import UnitSystem, convert_units
 from linkml_map.transformer.transformer import OBJECT_TYPE, Transformer
-from linkml_map.utils.dynamic_object import dynamic_object
-from linkml_map.utils.eval_utils import eval_expr
+from linkml_map.utils.dynamic_object import DynObj, dynamic_object
+from linkml_map.utils.eval_utils import eval_expr, eval_expr_with_mapping
 
 DICT_OBJ = Dict[str, Any]
 
 
 logger = logging.getLogger(__name__)
+
+
+class Bindings(Mapping):
+    """
+    Efficiently access source object attributes.
+    """
+
+    def __init__(
+        self,
+        object_transformer: "ObjectTransformer",
+        source_obj: OBJECT_TYPE,
+        source_obj_typed: OBJECT_TYPE,
+        source_type: str,
+        sv: SchemaView,
+        bindings: Dict,
+    ):
+        self.object_transformer: "ObjectTransformer" = object_transformer
+        self.source_obj: OBJECT_TYPE = source_obj
+        self.source_obj_typed: OBJECT_TYPE = source_obj_typed
+        self.source_type: str = source_type
+        self.sv: SchemaView = sv
+        self.bindings: Dict = {}
+        if bindings:
+            self.bindings.update(bindings)
+
+    def get_ctxt_obj_and_dict(self, source_obj: OBJECT_TYPE = None) -> Tuple[DynObj, OBJECT_TYPE]:
+        """
+        Transform a source object into a typed context object and dictionary, and cache results.
+
+        :param source_obj: Source data. Should be a subset of source_obj provided in the constructor.
+        If None the full source_obj from constructor is used.
+        :return: Tuple of typed context object and context dictionary. The object is the dictionary
+        with keys converted to member variables.
+        """
+        if source_obj is None:
+            source_obj = self.source_obj
+            
+        if self.object_transformer.object_index:
+            if not self.source_obj_typed:
+                source_obj_dyn = dynamic_object(source_obj, self.sv, self.source_type)
+            else:
+                source_obj_dyn = self.source_obj_typed
+            # Clear cache: Cache doesn't work since the cache key is the same when source_obj has only a subset
+            # of its keys. eg. {"age": self.source_obj["age"]} and {"name": self.source_obj["name"]}
+            # (with optionally the identifier key included) will have the same cache key, and so `bless` will
+            # incorrectly return the same cached values.
+            self.object_transformer.object_index.clear_proxy_object_cache()
+                
+            ctxt_obj = self.object_transformer.object_index.bless(source_obj_dyn)
+            ctxt_dict = {
+                k: getattr(ctxt_obj, k) for k in ctxt_obj._attributes() if not k.startswith("_")
+            }
+        else:
+            do = dynamic_object(source_obj, self.sv, self.source_type)
+            ctxt_obj = do
+            ctxt_dict = vars(do)
+
+        self.bindings.update(ctxt_dict)
+
+        return ctxt_obj, ctxt_dict
+    
+    def _all_keys(self) -> List[Any]:
+        keys = list(self.source_obj.keys()) + list(self.bindings.keys())
+        # Remove duplicate keys (ie. found in both source_obj and bindings), and retain original order
+        keys = list(dict.fromkeys(keys).keys())
+        return keys
+
+    def __len__(self) -> int:
+        return len(self._all_keys())
+    
+    def __iter__(self) -> Iterator:
+        return iter(self._all_keys())
+    
+    def __getitem__(self, name: Any) -> Any:
+        if name not in self.bindings:
+            _ = self.get_ctxt_obj_and_dict({name: self.source_obj[name]})
+        
+        return self.bindings.get(name)
+
+    def __setitem__(self, name: Any, value: Any):
+        del name, value
+        raise RuntimeError(f"__setitem__ not allowed on class {self.__class__.__name__}")
 
 
 @dataclass
@@ -112,7 +196,7 @@ class ObjectTransformer(Transformer):
             return source_obj
         class_deriv = self._get_class_derivation(source_type)
         tgt_attrs = {}
-        ctxt_obj = ctxt_dict = None
+        bindings = None
         # map each slot assignment in source_obj, if there is a slot_derivation
         for slot_derivation in class_deriv.slot_derivations.values():
             v = None
@@ -120,28 +204,22 @@ class ObjectTransformer(Transformer):
             if slot_derivation.unit_conversion:
                 v = self._perform_unit_conversion(slot_derivation, source_obj, sv, source_type)
             elif slot_derivation.expr:
-                if ctxt_obj is None:
-                    if self.object_index:
-                        if not source_obj_typed:
-                            source_obj_dyn = dynamic_object(source_obj, sv, source_type)
-                        else:
-                            source_obj_dyn = source_obj_typed
-                        ctxt_obj = self.object_index.bless(source_obj_dyn)
-                        ctxt_dict = {
-                            k: getattr(ctxt_obj, k)
-                            for k in ctxt_obj._attributes()
-                            if not k.startswith("_")
-                        }
-                    else:
-                        do = dynamic_object(source_obj, sv, source_type)
-                        ctxt_obj = do
-                        ctxt_dict = vars(do)
-
+                if bindings is None:
+                    bindings = Bindings(
+                        self,
+                        source_obj=source_obj,
+                        source_obj_typed=source_obj_typed,
+                        source_type=source_type,
+                        sv=sv,
+                        bindings={"NULL": None},
+                    )
+                    
                 try:
-                    v = eval_expr(slot_derivation.expr, **ctxt_dict, NULL=None)
+                    v = eval_expr_with_mapping(slot_derivation.expr, bindings)
                 except Exception:
                     if not self.unrestricted_eval:
                         raise RuntimeError(f"Expression not in safe subset: {slot_derivation.expr}")
+                    ctxt_obj, _ = bindings.get_ctxt_obj_and_dict()
                     aeval = Interpreter(usersyms={"src": ctxt_obj, "target": None})
                     aeval(slot_derivation.expr)
                     v = aeval.symtable["target"]

--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -8,6 +8,7 @@ TODO: move to core
 
 import ast
 import operator as op
+from collections.abc import Mapping
 
 # supported operators
 from typing import Any, List, Tuple
@@ -52,6 +53,21 @@ class UnsetValueError(Exception):
     pass
 
 
+def eval_expr_with_mapping(expr: str, mapping: Mapping) -> Any:
+    """
+    Evaluates a given expression, with restricted syntax.
+    This function is equivalent to eval_expr where **kwargs has been switched to a Mapping (eg. a dictionary).
+    See eval_expr for details.
+    """
+    if expr == "None":
+        # TODO: do this as part of parsing
+        return None
+    try:
+        return eval_(ast.parse(expr, mode="eval").body, mapping)
+    except UnsetValueError:
+        return None
+
+
 def eval_expr(expr: str, **kwargs) -> Any:
     """
     Evaluates a given expression, with restricted syntax
@@ -94,15 +110,7 @@ def eval_expr(expr: str, **kwargs) -> Any:
 
     :param expr: expression to evaluate
     """
-    # if kwargs:
-    #    expr = expr.format(**kwargs)
-    if expr == "None":
-        # TODO: do this as part of parsing
-        return None
-    try:
-        return eval_(ast.parse(expr, mode="eval").body, kwargs)
-    except UnsetValueError:
-        return None
+    return eval_expr_with_mapping(expr, kwargs)
 
 
 def eval_(node, bindings=None):


### PR DESCRIPTION
This PR deals with issue #27, and addresses both points in that issue. It addresses performance issues with expr slots in a slot_derivation. The first point in the issue was that bindings are recalculated any time an expr slot is found, and the recalculation occurs even if the bindings are the same. The second point was that when the bindings are calculated, ALL bindings are calculated, whether that binding is used or not. To address this, I created a Bindings class in object_transformer.py that calculates a binding only when requested with the get method. This class is derived from the Mappings class which behaves like a regular dictionary. The code for calculating the bindings is the same as the code that was previously found in ObjectTransformer.map_object() for expr slots, it has been placed in Bindings.get_ctxt_obj_and_dict() and the resulting bindings are cached in Bindings.bindings. Bindings.get_ctxt_obj_and_dict() is called from Bindings.__getitem__, using only the item requested. Also, eval_utils.eval_expr_with_mapping() has been added, which is the same as eval_expr but a Mapping object is used as the bindings parameter, instead of **kwargs (eval_expr has also been changed to simply call eval_expr_with_mapping).

One problem with this is that the cache keys used by ObjectIndex will be the same for the various different objects passed to ObjectIndex.bless, even if different dictionary keys are passed in from the source object. This means a possibly incorrect cached ProxyObject might be returned. To deal with this the cache is cleared by calling object_index.clear_proxy_object_cache(). This is a bit messy so suggestions for cleaning this up are welcome.

An important thing to keep in mind is that if an unrestricted evaluation is required for executing the code from an expr slot, then ALL bindings/variables are required to execute the code with asteval.Interpreter. This can be found in the except block where bindings.get_ctxt_obj_and_dict() is called (with None as a parameter to specify that ALL bindings are requested).

A simpler solution that is a bit cleaner (but not as good performance-wise) is found in expr-opt-b.

Fixes #27