### PR TITLE
Converting all unit tests to pytest

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -1,4 +1,6 @@
-import unittest
+"""Tests all command-line subcommands."""
+
+import pytest
 
 import yaml
 from click.testing import CliRunner
@@ -16,67 +18,67 @@ from tests import (
 )
 
 
-class TestCommandLineInterface(unittest.TestCase):
-    """
-    Tests all command-line subcommands
-    """
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
 
-    def setUp(self) -> None:
-        runner = CliRunner(mix_stderr=False)
-        self.runner = runner
 
-    def test_main_help(self):
-        result = self.runner.invoke(main, ["--help"])
-        out = result.stdout
-        self.assertIn("derive-schema", out)
-        self.assertIn("map-data", out)
-        self.assertEqual(0, result.exit_code)
+def test_main_help(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--help"])
+    out = result.stdout
+    assert "derive-schema" in out
+    assert "map-data" in out
+    assert result.exit_code == 0
 
-    def test_derive_schema(self):
-        cmd = ["derive-schema", "-T", str(PERSONINFO_TR), str(PERSONINFO_SRC_SCHEMA)]
-        result = self.runner.invoke(main, cmd)
-        self.assertEqual(0, result.exit_code)
-        out = result.stdout
-        # schema = yaml_loader.loads(str(out), SchemaDefinition)
-        # expected = yaml_loader.load(str(PERSONINFO_TGT_SCHEMA), SchemaDefinition)
-        # self.ensure_schemas_equivalent(schema, expected)
-        sv = SchemaView(out)
-        self.assertIn("Agent", sv.all_classes().keys())
-        # self.assertIn("NamedThing", sv.all_classes().keys())
 
-    def test_map_data(self):
-        cmd = [
-            "map-data",
-            "--unrestricted-eval",
-            "-T",
-            str(PERSONINFO_TR),
-            "-s",
-            str(PERSONINFO_SRC_SCHEMA),
-            str(PERSONINFO_CONTAINER_DATA),
-        ]
-        result = self.runner.invoke(main, cmd)
-        self.assertEqual(0, result.exit_code)
-        out = result.stdout
-        tr_data = yaml.safe_load(out)
-        self.assertEqual("fred bloggs", tr_data["agents"][0]["label"])
+def test_derive_schema(runner: CliRunner) -> None:
+    cmd = ["derive-schema", "-T", str(PERSONINFO_TR), str(PERSONINFO_SRC_SCHEMA)]
+    result = runner.invoke(main, cmd)
+    assert result.exit_code == 0
+    out = result.stdout
+    # schema = yaml_loader.loads(str(out), SchemaDefinition)
+    # expected = yaml_loader.load(str(PERSONINFO_TGT_SCHEMA), SchemaDefinition)
+    # self.ensure_schemas_equivalent(schema, expected)
+    sv = SchemaView(out)
+    assert "Agent" in sv.all_classes().keys()
+    # self.assertIn("NamedThing", sv.all_classes().keys())
 
-    def test_map_data2(self):
-        cmd = [
-            "map-data",
-            "-T",
-            str(DENORM_SPECIFICATION),
-            "-s",
-            str(NORM_SCHEMA),
-            str(FLATTENING_DATA),
-        ]
-        result = self.runner.invoke(main, cmd)
-        self.assertEqual(0, result.exit_code)
-        out = result.stdout
-        tr_data = yaml.safe_load(out)
-        m = tr_data["mappings"][0]
-        self.assertEqual(m["subject_id"], "X:1")
-        self.assertEqual(m["subject_name"], "x1")
 
-    def ensure_schemas_equivalent(self, s1: SchemaDefinition, s2: SchemaDefinition):
-        self.assertCountEqual(s1.classes, s2.classes)
-        self.assertCountEqual(s1.slots, s2.slots)
+def test_map_data(runner: CliRunner) -> None:
+    cmd = [
+        "map-data",
+        "--unrestricted-eval",
+        "-T",
+        str(PERSONINFO_TR),
+        "-s",
+        str(PERSONINFO_SRC_SCHEMA),
+        str(PERSONINFO_CONTAINER_DATA),
+    ]
+    result = runner.invoke(main, cmd)
+    assert result.exit_code == 0
+    out = result.stdout
+    tr_data = yaml.safe_load(out)
+    assert "fred bloggs" == tr_data["agents"][0]["label"]
+
+
+def test_map_data2(runner: CliRunner) -> None:
+    cmd = [
+        "map-data",
+        "-T",
+        str(DENORM_SPECIFICATION),
+        "-s",
+        str(NORM_SCHEMA),
+        str(FLATTENING_DATA),
+    ]
+    result = runner.invoke(main, cmd)
+    assert result.exit_code == 0
+    out = result.stdout
+    tr_data = yaml.safe_load(out)
+    m = tr_data["mappings"][0]
+    assert m["subject_id"] == "X:1"
+    assert m["subject_name"] == "x1"
+
+
+def ensure_schemas_equivalent(s1: SchemaDefinition, s2: SchemaDefinition):
+    assert len(s1.classes) == len(s2.classes)
+    assert len(s1.slots) == len(s2.slots)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1,25 +1,63 @@
-import unittest
+"""Tests the data model."""
 
 from linkml_map.transformer.object_transformer import ObjectTransformer
 from tests import PERSONINFO_TR
 
 
-class DatamodelTestCase(unittest.TestCase):
-    """
-    tests the data model
-    """
+def test_datamodel():
+    """checks loading/retrieval"""
+    tr = ObjectTransformer()
+    tr.load_transformer_specification(PERSONINFO_TR)
+    # print(tr_spec.json())
+    trs = tr.specification
+    assert trs.model_dump_json() != ""
+    assert trs.source_schema == "s1"
+    assert trs.target_schema == "s2"
 
-    def setUp(self) -> None:
-        tr = ObjectTransformer()
-        tr.load_transformer_specification(PERSONINFO_TR)
-        self.tr_spec = tr.specification
+    # class derivations
+    class_derivs = {
+        "Container": "Container",
+        "Entity": None,
+        "Agent": "Person",
+        "Job": None,
+        "Address": "Address",
+        "FamilialRelationship": "FamilialRelationship",
+        "SequenceFeature": None,
+        "DenormMapping": "Mapping",
+    }
+    for clss, spec in trs.class_derivations.items():
+        assert class_derivs[clss] == spec.populated_from
 
-    def test_datamodel(self):
-        """checks loading/retrieval"""
-        tr_spec = self.tr_spec
-        # print(tr_spec.json())
-        self.assertNotEqual("", tr_spec.json())
+    # slot derivations
+    agent_slots = trs.class_derivations["Agent"].slot_derivations
+    # populated from
+    assert agent_slots["label"].populated_from == "name"
 
+    # one line expression
+    assert agent_slots["age"].expr == "str({age_in_years}) + ' years'"
 
-if __name__ == "__main__":
-    unittest.main()
+    # multi-line expr
+    assert (
+        agent_slots["driving_since"].expr
+        == 'd_test = [x.important_event_date for x in src.has_important_life_events if str(x.event_name) == "PASSED_DRIVING_TEST"]\nif len(d_test):\n    target = d_test[0]\n'
+    )
+
+    assert agent_slots["primary_email"].expr is None
+    assert agent_slots["secondary_email"].expr == "NULL"
+    # this should be fixed!
+    assert agent_slots["gender"].expr == "None"
+
+    assert agent_slots["id"].populated_from is None
+    assert agent_slots["id"].expr is None
+
+    # enum derivations
+    assert len(trs.enum_derivations) == 1
+    assert (
+        trs.enum_derivations["MyFamilialRelationshipType"].populated_from
+        == "FamilialRelationshipType"
+    )
+    assert {"SIBLING_OF", "CHILD_OF"} == set(
+        trs.enum_derivations[
+            "MyFamilialRelationshipType"
+        ].permissible_value_derivations.keys()
+    )

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -1,7 +1,9 @@
+"""Test the object transformer."""
+
 import itertools
-import unittest
 from typing import Any
 
+import pytest
 import yaml
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import (
@@ -53,361 +55,368 @@ CONTAINER_OBJECT = yaml_loader.load(
 )
 
 
-class ObjectTransformerTestCase(unittest.TestCase):
+@pytest.fixture
+def obj_tr() -> ObjectTransformer:
+    obj_tr = ObjectTransformer(unrestricted_eval=True)
+    obj_tr.source_schemaview = SchemaView(str(PERSONINFO_SRC_SCHEMA))
+    obj_tr.target_schemaview = SchemaView(str(PERSONINFO_TGT_SCHEMA))
+    obj_tr.load_transformer_specification(PERSONINFO_TR)
+    return obj_tr
+
+
+def test_transform_dict(obj_tr: ObjectTransformer) -> None:
     """
-    Tests ObjectTransformer
+    Tests transforming a dictionary of Person data
+    into a dictionary of Agent data
     """
+    person_dict: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_DATA)))
+    assert person_dict["age_in_years"] == AGE_INT
+    target_dict: dict[str, Any] = obj_tr.map_object(person_dict, source_type="Person")
+    assert isinstance(target_dict, type(TARGET_DATA))
+    assert target_dict["age"] == AGE_STRING
+    assert target_dict == TARGET_DATA
 
-    def setUp(self) -> None:
-        tr = ObjectTransformer(unrestricted_eval=True)
-        tr.source_schemaview = SchemaView(str(PERSONINFO_SRC_SCHEMA))
-        tr.target_schemaview = SchemaView(str(PERSONINFO_TGT_SCHEMA))
-        tr.load_transformer_specification(PERSONINFO_TR)
-        self.tr: ObjectTransformer = tr
 
-    def test_transform_dict(self) -> None:
-        """
-        Tests transforming a dictionary of Person data
-        into a dictionary of Agent data
-        """
-        tr = self.tr
-        person_dict: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_DATA)))
-        assert person_dict["age_in_years"] == AGE_INT
-        target_dict: dict[str, Any] = tr.map_object(person_dict, source_type="Person")
-        assert isinstance(target_dict, type(TARGET_DATA))
-        assert target_dict["age"] == AGE_STRING
-        assert target_dict == TARGET_DATA
+def test_transform_dict_in_container(obj_tr: ObjectTransformer):
+    """
+    Tests transforming a Person data dict in a Container
+    into an Agent data dict in a Container dict
+    """
+    person_dict: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_DATA)))
+    container_dict = {"persons": [person_dict]}
+    target_dict = obj_tr.map_object(container_dict, source_type="Container")
+    assert target_dict == {"agents": [TARGET_DATA]}
 
-    def test_transform_dict_in_container(self):
-        """
-        Tests transforming a Person data dict in a Container
-        into an Agent data dict in a Container dict
-        """
-        tr = self.tr
-        person_dict: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_DATA)))
-        container_dict = {"persons": [person_dict]}
-        target_dict = tr.map_object(container_dict, source_type="Container")
-        assert target_dict == {"agents": [TARGET_DATA]}
 
-    def test_transform_multiple_dicts_in_container(self) -> None:
-        """
-        Tests transforming several Person data dicts in a Container
-        into Agent data dicts in a Container dicts
-        """
-        tr = self.tr
-        container_dict: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_CONTAINER_DATA)))
-        target_dict: dict[str, Any] = tr.map_object(container_dict, source_type="Container")
-        assert target_dict == CONTAINER_DATA
+def test_transform_multiple_dicts_in_container(obj_tr: ObjectTransformer) -> None:
+    """
+    Tests transforming several Person data dicts in a Container
+    into Agent data dicts in a Container dicts
+    """
+    container_dict: dict[str, Any] = yaml.safe_load(
+        open(str(PERSONINFO_CONTAINER_DATA))
+    )
+    target_dict: dict[str, Any] = obj_tr.map_object(
+        container_dict, source_type="Container"
+    )
+    assert target_dict == CONTAINER_DATA
 
-    def check_familial_relationships(self, obj, data_model, expected):
-        assert len(expected) == len(obj.has_familial_relationships)
-        for n in range(len(expected)):
-            fr = obj.has_familial_relationships[n]
-            assert isinstance(fr, data_model.FamilialRelationship)
-            assert expected[n]["related_to"] == fr.related_to
-            assert expected[n]["type"] == str(fr.type)
 
-    def test_coerce(self):
-        tr: ObjectTransformer = self.tr
-        x = tr._coerce_datatype("5", "integer")
-        self.assertEqual(5, x)
-        x = tr._coerce_datatype(5, "string")
-        self.assertEqual("5", x)
-        x = tr._coerce_datatype(5, "integer")
-        self.assertEqual(5, x)
+def check_familial_relationships(obj, data_model, expected):
+    assert len(expected) == len(obj.has_familial_relationships)
+    for n in range(len(expected)):
+        fr = obj.has_familial_relationships[n]
+        assert isinstance(fr, data_model.FamilialRelationship)
+        assert expected[n]["related_to"] == fr.related_to
+        assert expected[n]["type"] == str(fr.type)
 
-    def test_transform_simple_object(self):
-        """
-        Tests transforming a Person object
-        into an Agent object
-        """
-        tr: ObjectTransformer = self.tr
-        person_obj: src_dm.Person = yaml_loader.load(
-            str(PERSONINFO_DATA), target_class=src_dm.Person
-        )
-        assert isinstance(person_obj, src_dm.Person)
-        assert person_obj.age_in_years == AGE_INT
 
-        expected = [
-            {
-                "related_to": "P:002",
-                "type": "SIBLING_OF",
-                "enum": src_dm.FamilialRelationshipType.SIBLING_OF,
-            },
-            {
-                "related_to": "P:003",
-                "type": "CHILD_OF",
-                "enum": src_dm.FamilialRelationshipType.CHILD_OF,
-            },
-        ]
-        self.check_familial_relationships(person_obj, src_dm, expected)
-        # TODO: move these tests to `check_familial_relationships` once
-        # enum derivations are implemented
-        for n in range(len(expected)):
-            fr = person_obj.has_familial_relationships[n]
-            assert src_dm.FamilialRelationshipType(expected[n]["enum"]) == fr.type
+def test_coerce(obj_tr: ObjectTransformer):
+    x = obj_tr._coerce_datatype("5", "integer")
+    assert x == 5
+    x = obj_tr._coerce_datatype(5, "string")
+    assert "5" == x
+    x = obj_tr._coerce_datatype(5, "integer")
+    assert 5 == x
 
-        target_obj = tr.transform_object(person_obj, target_class=tgt_dm.Agent)
-        assert isinstance(target_obj, tgt_dm.Agent)
-        assert person_obj.name == target_obj.label
-        assert AGE_STRING == target_obj.age
-        assert target_obj.gender is None
 
-        expected = [
-            {
-                "related_to": "P:002",
-                "type": "SIBLING_OF",
-                # TODO: enum derivations
-                # "enum": tgt_dm.MyFamilialRelationshipType.SIBLING_OF,
-            },
-            {
-                "related_to": "P:003",
-                "type": "CHILD_OF",
-                # TODO: enum derivations
-                # "enum": tgt_dm.MyFamilialRelationshipType.CHILD_OF,
-            },
-        ]
-        self.check_familial_relationships(target_obj, tgt_dm, expected)
-        assert target_obj == TARGET_OBJECT
+def test_transform_simple_object(obj_tr: ObjectTransformer):
+    """
+    Tests transforming a Person object
+    into an Agent object
+    """
+    person_obj: src_dm.Person = yaml_loader.load(
+        str(PERSONINFO_DATA), target_class=src_dm.Person
+    )
+    assert isinstance(person_obj, src_dm.Person)
+    assert person_obj.age_in_years == AGE_INT
 
-    def test_transform_container_object(self):
-        """
-        Tests transforming a Container object holding a Person object
-        into Container object holding an Agent object
-        """
-        tr = self.tr
-        person = yaml_loader.load(str(PERSONINFO_DATA), target_class=src_dm.Person)
-        container_obj = src_dm.Container(persons=[person])
-        result: tgt_dm.Container = tr.transform_object(container_obj, target_class=tgt_dm.Container)
-        assert isinstance(result, tgt_dm.Container)
-        agents = result.agents
-        agent = agents[0]
-        assert agent.label == person.name
-        assert agent.age == AGE_STRING
-        assert agent == TARGET_OBJECT
-        for rel in [0, 1]:
-            person_fr1 = person.has_familial_relationships[rel]
-            agent_fr1 = agent.has_familial_relationships[rel]
-            assert person_fr1.related_to == agent_fr1.related_to
+    expected = [
+        {
+            "related_to": "P:002",
+            "type": "SIBLING_OF",
+            "enum": src_dm.FamilialRelationshipType.SIBLING_OF,
+        },
+        {
+            "related_to": "P:003",
+            "type": "CHILD_OF",
+            "enum": src_dm.FamilialRelationshipType.CHILD_OF,
+        },
+    ]
+    check_familial_relationships(person_obj, src_dm, expected)
+    # TODO: move these tests to `check_familial_relationships` once
+    # enum derivations are implemented
+    for n in range(len(expected)):
+        fr = person_obj.has_familial_relationships[n]
+        assert src_dm.FamilialRelationshipType(expected[n]["enum"]) == fr.type
 
-    def test_transform_object_container(self):
-        """
-        Tests transforming a Container object holding several Person objects
-        into Container object holding several Agent objects
-        """
-        tr = self.tr
-        container_obj = yaml_loader.load(
-            str(PERSONINFO_CONTAINER_DATA), target_class=src_dm.Container
-        )
-        target_obj = tr.transform_object(container_obj, target_class=tgt_dm.Container)
-        assert target_obj.agents[0] == TARGET_OBJECT
-        assert target_obj == CONTAINER_OBJECT
+    target_obj = obj_tr.transform_object(person_obj, target_class=tgt_dm.Agent)
+    assert isinstance(target_obj, tgt_dm.Agent)
+    assert person_obj.name == target_obj.label
+    assert AGE_STRING == target_obj.age
+    assert target_obj.gender is None
 
-    def check_subject_object_predicate(
-        self,
-        obj,
-        expected,
-    ):
-        assert expected["subject_id"] == obj.subject.id
-        assert expected["subject_name"] == obj.subject.name
-        assert expected["object_id"] == obj.object.id
-        assert expected["object_name"] == obj.object.name
-        assert expected["predicate"] == obj.predicate
+    expected = [
+        {
+            "related_to": "P:002",
+            "type": "SIBLING_OF",
+            # TODO: enum derivations
+            # "enum": tgt_dm.MyFamilialRelationshipType.SIBLING_OF,
+        },
+        {
+            "related_to": "P:003",
+            "type": "CHILD_OF",
+            # TODO: enum derivations
+            # "enum": tgt_dm.MyFamilialRelationshipType.CHILD_OF,
+        },
+    ]
+    check_familial_relationships(target_obj, tgt_dm, expected)
+    assert target_obj == TARGET_OBJECT
 
-    def test_index_dict(self):
-        sv = SchemaView(NORM_SCHEMA)
-        container = yaml.safe_load(open(str(FLATTENING_DATA)))
-        dynobj = dynamic_object(container, sv, "MappingSet")
-        m = dynobj.mappings[0]
-        tr = ObjectTransformer()
-        tr.source_schemaview = sv
-        tr.index(container, "MappingSet")
-        ix = tr.object_index
-        mp = ix.bless(m)
-        self.check_subject_object_predicate(
-            mp,
-            {
-                "subject_id": "X:1",
-                "subject_name": "x1",
-                "object_id": "Y:1",
-                "object_name": "y1",
-                "predicate": "P:1",
-            },
-        )
-        container["mappings"][0]["subject"] = "U:1"
-        tr.index(container, "MappingSet")
-        dynobj = dynamic_object(container, sv, "MappingSet")
-        mset = ix.bless(dynobj)
-        assert "U:1" == mset.mappings[0].subject
-        assert "Y:1" == mset.mappings[0].object.id
-        assert "y1" == mset.mappings[0].object.name
-        assert "P:1" == mset.mappings[0].predicate
 
-    def test_index_obj(self):
-        sv = SchemaView(NORM_SCHEMA)
-        mset: sssom_src_dm.MappingSet = yaml_loader.load(
-            str(FLATTENING_DATA), target_class=sssom_src_dm.MappingSet
-        )
-        m = mset.mappings[0]
-        tr = ObjectTransformer()
-        tr.source_schemaview = sv
-        tr.index(mset, "MappingSet")
-        ix = tr.object_index
-        mp = ix.bless(m)
-        self.check_subject_object_predicate(
-            mp,
-            {
-                "subject_id": "X:1",
-                "subject_name": "x1",
-                "object_id": "Y:1",
-                "object_name": "y1",
-                "predicate": "P:1",
-            },
-        )
+def test_transform_container_object(obj_tr: ObjectTransformer):
+    """
+    Tests transforming a Container object holding a Person object
+    into Container object holding an Agent object
+    """
+    person = yaml_loader.load(str(PERSONINFO_DATA), target_class=src_dm.Person)
+    container_obj = src_dm.Container(persons=[person])
+    result: tgt_dm.Container = obj_tr.transform_object(
+        container_obj, target_class=tgt_dm.Container
+    )
+    assert isinstance(result, tgt_dm.Container)
+    agents = result.agents
+    agent = agents[0]
+    assert agent.label == person.name
+    assert agent.age == AGE_STRING
+    assert agent == TARGET_OBJECT
+    for rel in [0, 1]:
+        person_fr1 = person.has_familial_relationships[rel]
+        agent_fr1 = agent.has_familial_relationships[rel]
+        assert person_fr1.related_to == agent_fr1.related_to
 
-        mset.mappings[0].subject = "U:1"
-        tr.index(mset, "MappingSet")
-        mset = ix.bless(mset)
-        expected = {
-            "subject_id": "U:1",
-            "subject_name": None,
-            "object_id": "Y:1",
-            "object_name": "y1",
-            "predicate": "P:1",
-        }
-        self.check_subject_object_predicate(mset.mappings[0], expected)
 
-    def test_denormalized_transform_dict(self):
-        """
-        Tests denormalizing transformation.
+def test_transform_object_container(obj_tr: ObjectTransformer):
+    """
+    Tests transforming a Container object holding several Person objects
+    into Container object holding several Agent objects
+    """
+    container_obj = yaml_loader.load(
+        str(PERSONINFO_CONTAINER_DATA), target_class=src_dm.Container
+    )
+    target_obj = obj_tr.transform_object(container_obj, target_class=tgt_dm.Container)
+    assert target_obj.agents[0] == TARGET_OBJECT
+    assert target_obj == CONTAINER_OBJECT
 
-        The test input is a normalized Mapping class with subject and object that reference a separate
-        entities class, which has id and name fields.
 
-        The denormalized output has fields like subject_id
-        """
-        tr = ObjectTransformer()
-        tr.source_schemaview = SchemaView(NORM_SCHEMA)
-        tr.target_schemaview = SchemaView(DENORM_SCHEMA)
-        tr.load_transformer_specification(DENORM_SPECIFICATION)
-        mset = yaml.safe_load(open(str(FLATTENING_DATA)))
-        assert mset["mappings"] == [{"subject": "X:1", "object": "Y:1", "predicate": "P:1"}]
-        assert mset["entities"] == {"X:1": {"name": "x1"}, "Y:1": {"name": "y1"}}
-        tr.index(mset, "MappingSet")
-        target_obj = tr.map_object(mset, source_type="MappingSet")
-        assert isinstance(target_obj, dict)
-        assert target_obj["mappings"][0] == {
+def check_subject_object_predicate(
+    obj,
+    expected,
+):
+    assert expected["subject_id"] == obj.subject.id
+    assert expected["subject_name"] == obj.subject.name
+    assert expected["object_id"] == obj.object.id
+    assert expected["object_name"] == obj.object.name
+    assert expected["predicate"] == obj.predicate
+
+
+def test_index_dict():
+    sv = SchemaView(NORM_SCHEMA)
+    container = yaml.safe_load(open(str(FLATTENING_DATA)))
+    dynobj = dynamic_object(container, sv, "MappingSet")
+    m = dynobj.mappings[0]
+    tr = ObjectTransformer()
+    tr.source_schemaview = sv
+    tr.index(container, "MappingSet")
+    ix = tr.object_index
+    mp = ix.bless(m)
+    check_subject_object_predicate(
+        mp,
+        {
             "subject_id": "X:1",
             "subject_name": "x1",
             "object_id": "Y:1",
             "object_name": "y1",
-            "predicate_id": "P:1",
-        }
+            "predicate": "P:1",
+        },
+    )
+    container["mappings"][0]["subject"] = "U:1"
+    tr.index(container, "MappingSet")
+    dynobj = dynamic_object(container, sv, "MappingSet")
+    mset = ix.bless(dynobj)
+    assert "U:1" == mset.mappings[0].subject
+    assert "Y:1" == mset.mappings[0].object.id
+    assert "y1" == mset.mappings[0].object.name
+    assert "P:1" == mset.mappings[0].predicate
 
-    def test_denormalized_object_transform(self):
-        """
-        Tests denormalizing transformation.
 
-        The test input is a normalized Mapping class with subject and object that reference a separate
-        entities class, which has id and name fields.
+def test_index_obj():
+    sv = SchemaView(NORM_SCHEMA)
+    mset: sssom_src_dm.MappingSet = yaml_loader.load(
+        str(FLATTENING_DATA), target_class=sssom_src_dm.MappingSet
+    )
+    m = mset.mappings[0]
+    tr = ObjectTransformer()
+    tr.source_schemaview = sv
+    tr.index(mset, "MappingSet")
+    ix = tr.object_index
+    mp = ix.bless(m)
+    check_subject_object_predicate(
+        mp,
+        {
+            "subject_id": "X:1",
+            "subject_name": "x1",
+            "object_id": "Y:1",
+            "object_name": "y1",
+            "predicate": "P:1",
+        },
+    )
 
-        The denormalized output has fields like subject_id
-        """
-        tr = ObjectTransformer()
-        tr.source_schemaview = SchemaView(NORM_SCHEMA)
-        tr.target_schemaview = SchemaView(DENORM_SCHEMA)
-        tr.target_module = sssom_tgt_dm
-        tr.load_transformer_specification(DENORM_SPECIFICATION)
-        mset: sssom_src_dm.MappingSet = yaml_loader.load(
-            str(FLATTENING_DATA), target_class=sssom_src_dm.MappingSet
-        )
-        mapping = mset.mappings[0]
-        assert mapping.subject == "X:1"
-        assert mapping.object == "Y:1"
-        assert mset.entities["X:1"].name == "x1"
-        assert mset.entities["Y:1"].name == "y1"
-        tr.index(mset)
-        mset_proxy = tr.object_index.bless(mset)
-        assert mset_proxy.mappings[0].subject.id == "X:1"
-        assert mset_proxy.mappings[0].subject.name == "x1"
-        target_obj: sssom_tgt_dm.MappingSet = tr.transform_object(
-            mset, target_class=sssom_tgt_dm.MappingSet
-        )
-        mapping = target_obj.mappings[0]
-        assert mapping.subject_id == "X:1"
-        assert mapping.subject_name == "x1"
-        assert mapping.object_id == "Y:1"
-        assert mapping.object_name == "y1"
-        # dangling reference
-        mset.mappings[0].subject = "U:1"
-        tr.index(mset)
-        mset_proxy = tr.object_index.bless(mset)
-        assert mset_proxy.mappings[0].subject.id == "U:1"
-        self.assertIsNone(mset_proxy.mappings[0].subject.name)
-        target_obj = tr.transform_object(mset, target_class=sssom_tgt_dm.MappingSet)
-        mapping = target_obj.mappings[0]
-        assert mapping.subject_id == "U:1"
-        self.assertIsNone(mapping.subject_name)
-        assert mapping.object_id == "Y:1"
-        assert mapping.object_name == "y1"
+    mset.mappings[0].subject = "U:1"
+    tr.index(mset, "MappingSet")
+    mset = ix.bless(mset)
+    expected = {
+        "subject_id": "U:1",
+        "subject_name": None,
+        "object_id": "Y:1",
+        "object_name": "y1",
+        "predicate": "P:1",
+    }
+    check_subject_object_predicate(mset.mappings[0], expected)
 
-    def test_cardinalities(self):
-        """
-        Tests enforcing cardinality
-        """
-        tf = [True, False]
-        class_name = "MyClass"
-        att_name = "my_att"
-        val = "v1"
-        for source_multivalued, target_multivalued, explicit in itertools.product(tf, tf, tf):
 
-            def mk(mv: bool, explicit: bool = False):
-                cls = ClassDefinition(class_name)
-                # TODO: it should not be necessary to set this if present in Transformation
-                # att = SlotDefinition(att_name, multivalued=mv and not explicit)
-                att = SlotDefinition(att_name, multivalued=mv)
-                cls.attributes[att.name] = att
-                schema = SchemaDefinition(
-                    name="test", id="test", classes=[cls], default_range="string"
-                )
-                return schema
+def test_denormalized_transform_dict():
+    """
+    Tests denormalizing transformation.
 
-            source_schema = mk(source_multivalued)
-            target_schema = mk(target_multivalued, explicit)
-            specification = TransformationSpecification(id="test")
-            cd = ClassDerivation(name=class_name, populated_from=class_name)
-            specification.class_derivations[class_name] = cd
-            sd = SlotDerivation(name=att_name, populated_from=att_name)
-            if explicit:
-                sd.cast_collection_as = (
-                    CollectionType.MultiValued
-                    if target_multivalued
-                    else CollectionType.SingleValued
-                )
-            cd.slot_derivations[att_name] = sd
-            source_instance = {att_name: [val] if source_multivalued else val}
-            tr = ObjectTransformer(
-                specification=specification,
-                source_schemaview=SchemaView(source_schema),
-                target_schemaview=SchemaView(target_schema),
+    The test input is a normalized Mapping class with subject and object that reference a separate
+    entities class, which has id and name fields.
+
+    The denormalized output has fields like subject_id
+    """
+    tr = ObjectTransformer()
+    tr.source_schemaview = SchemaView(NORM_SCHEMA)
+    tr.target_schemaview = SchemaView(DENORM_SCHEMA)
+    tr.load_transformer_specification(DENORM_SPECIFICATION)
+    mset = yaml.safe_load(open(str(FLATTENING_DATA)))
+    assert mset["mappings"] == [{"subject": "X:1", "object": "Y:1", "predicate": "P:1"}]
+    assert mset["entities"] == {"X:1": {"name": "x1"}, "Y:1": {"name": "y1"}}
+    tr.index(mset, "MappingSet")
+    target_obj = tr.map_object(mset, source_type="MappingSet")
+    assert isinstance(target_obj, dict)
+    assert target_obj["mappings"][0] == {
+        "subject_id": "X:1",
+        "subject_name": "x1",
+        "object_id": "Y:1",
+        "object_name": "y1",
+        "predicate_id": "P:1",
+    }
+
+
+def test_denormalized_object_transform():
+    """
+    Tests denormalizing transformation.
+
+    The test input is a normalized Mapping class with subject and object that reference a separate
+    entities class, which has id and name fields.
+
+    The denormalized output has fields like subject_id
+    """
+    tr = ObjectTransformer()
+    tr.source_schemaview = SchemaView(NORM_SCHEMA)
+    tr.target_schemaview = SchemaView(DENORM_SCHEMA)
+    tr.target_module = sssom_tgt_dm
+    tr.load_transformer_specification(DENORM_SPECIFICATION)
+    mset: sssom_src_dm.MappingSet = yaml_loader.load(
+        str(FLATTENING_DATA), target_class=sssom_src_dm.MappingSet
+    )
+    mapping = mset.mappings[0]
+    assert mapping.subject == "X:1"
+    assert mapping.object == "Y:1"
+    assert mset.entities["X:1"].name == "x1"
+    assert mset.entities["Y:1"].name == "y1"
+    tr.index(mset)
+    mset_proxy = tr.object_index.bless(mset)
+    assert mset_proxy.mappings[0].subject.id == "X:1"
+    assert mset_proxy.mappings[0].subject.name == "x1"
+    target_obj: sssom_tgt_dm.MappingSet = tr.transform_object(
+        mset, target_class=sssom_tgt_dm.MappingSet
+    )
+    mapping = target_obj.mappings[0]
+    assert mapping.subject_id == "X:1"
+    assert mapping.subject_name == "x1"
+    assert mapping.object_id == "Y:1"
+    assert mapping.object_name == "y1"
+    # dangling reference
+    mset.mappings[0].subject = "U:1"
+    tr.index(mset)
+    mset_proxy = tr.object_index.bless(mset)
+    assert mset_proxy.mappings[0].subject.id == "U:1"
+    assert mset_proxy.mappings[0].subject.name is None
+    target_obj = tr.transform_object(mset, target_class=sssom_tgt_dm.MappingSet)
+    mapping = target_obj.mappings[0]
+    assert mapping.subject_id == "U:1"
+    assert mapping.subject_name is None
+    assert mapping.object_id == "Y:1"
+    assert mapping.object_name == "y1"
+
+
+def test_cardinalities():
+    """
+    Tests enforcing cardinality
+    """
+    tf = [True, False]
+    class_name = "MyClass"
+    att_name = "my_att"
+    val = "v1"
+    for source_multivalued, target_multivalued, explicit in itertools.product(
+        tf, tf, tf
+    ):
+
+        def mk(mv: bool, explicit: bool = False):
+            cls = ClassDefinition(class_name)
+            # TODO: it should not be necessary to set this if present in Transformation
+            # att = SlotDefinition(att_name, multivalued=mv and not explicit)
+            att = SlotDefinition(att_name, multivalued=mv)
+            cls.attributes[att.name] = att
+            schema = SchemaDefinition(
+                name="test", id="test", classes=[cls], default_range="string"
             )
-            target_instance = tr.map_object(source_instance, class_name)
-            assert [val] if target_multivalued else val == target_instance[att_name]
+            return schema
 
-    def test_self_transform(self):
-        tr = ObjectTransformer()
-        tr.source_schemaview = SchemaView(str(TR_SCHEMA))
-        tr.load_transformer_specification(TR_TO_MAPPING_TABLES)
-        source_object = yaml.safe_load(open(str(PERSONINFO_TR)))
-        normalizer = ReferenceValidator(
-            package_schemaview("linkml_map.datamodel.transformer_model")
+        source_schema = mk(source_multivalued)
+        target_schema = mk(target_multivalued, explicit)
+        specification = TransformationSpecification(id="test")
+        cd = ClassDerivation(name=class_name, populated_from=class_name)
+        specification.class_derivations[class_name] = cd
+        sd = SlotDerivation(name=att_name, populated_from=att_name)
+        if explicit:
+            sd.cast_collection_as = (
+                CollectionType.MultiValued
+                if target_multivalued
+                else CollectionType.SingleValued
+            )
+        cd.slot_derivations[att_name] = sd
+        source_instance = {att_name: [val] if source_multivalued else val}
+        tr = ObjectTransformer(
+            specification=specification,
+            source_schemaview=SchemaView(source_schema),
+            target_schemaview=SchemaView(target_schema),
         )
-        normalizer.expand_all = True
-        source_object = normalizer.normalize(source_object)
-        derived = tr.map_object(source_object)
-        print(derived)
-        print(yaml.dump(derived))
+        target_instance = tr.map_object(source_instance, class_name)
+        assert [val] if target_multivalued else val == target_instance[att_name]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_self_transform():
+    tr = ObjectTransformer()
+    tr.source_schemaview = SchemaView(str(TR_SCHEMA))
+    tr.load_transformer_specification(TR_TO_MAPPING_TABLES)
+    source_object = yaml.safe_load(open(str(PERSONINFO_TR)))
+    normalizer = ReferenceValidator(
+        package_schemaview("linkml_map.datamodel.transformer_model")
+    )
+    normalizer.expand_all = True
+    source_object = normalizer.normalize(source_object)
+    derived = tr.map_object(source_object)
+    print(derived)
+    print(yaml.dump(derived))

--- a/tests/test_transformer/test_transformer_examples.py
+++ b/tests/test_transformer/test_transformer_examples.py
@@ -1,5 +1,6 @@
-import unittest
+"""Tests ObjectTransformer using examples."""
 
+import pytest
 from linkml_map.utils.multi_file_transformer import MultiFileTransformer
 from tests import EXAMPLE_DIR
 
@@ -9,42 +10,43 @@ EXAMPLE_PROJECTS = [
 ]
 
 
-class TransformerExamplesTestCase(unittest.TestCase):
+"""
+Tests ObjectTransformer using examples.
+
+Assumes folder structures:
+
+- input/examples
+    - {package}
+        - source/{source_schema}.yaml  :: the schema to transform from
+        - transform/{transform_spec}.transform.yaml :: mapping spec
+        - data/{SourceClassName}-{LocalId}.yaml :: data to transform
+        - target/{SourceClassName}-{LocalId}.yaml :: expected output data
+"""
+
+
+def test_all():
     """
-    Tests ObjectTransformer using examples.
+    Iterates through all examples.
 
-    Assumes folder structures:
-
-    - input/examples
-       - {package}
-          - source/{source_schema}.yaml  :: the schema to transform from
-          - transform/{transform_spec}.transform.yaml :: mapping spec
-          - data/{SourceClassName}-{LocalId}.yaml :: data to transform
-          - target/{SourceClassName}-{LocalId}.yaml :: expected output data
+    This uses the MultiFileProcessor in test_mode - if the outputs differ
+    then the test will fail
     """
+    mft = MultiFileTransformer()
+    for directory in EXAMPLE_PROJECTS:
+        full_dir = EXAMPLE_DIR / directory
+        instructions = mft.infer_instructions(full_dir)
+        mft.process_instructions(instructions, full_dir, test_mode=True)
 
-    def test_all(self):
-        """
-        Iterates through all examples.
 
-        This uses the MultiFileProcessor in test_mode - if the outputs differ
-        then the test will fail
-        """
-        mft = MultiFileTransformer()
-        for directory in EXAMPLE_PROJECTS:
-            full_dir = EXAMPLE_DIR / directory
-            instructions = mft.infer_instructions(full_dir)
-            mft.process_instructions(instructions, full_dir, test_mode=True)
-
-    @unittest.skip("Uncomment this to regenerate examples")
-    def test_regenerate(self):
-        """
-        Use this to regenerate test examples.
-        """
-        mft = MultiFileTransformer()
-        dirs = EXAMPLE_PROJECTS
-        for directory in dirs:
-            full_dir = EXAMPLE_DIR / directory
-            instructions = mft.infer_instructions(full_dir)
-            # print(yaml.dump(instructions.dict()))
-            mft.process_instructions(instructions, full_dir, test_mode=False)
+@pytest.mark.skip("Uncomment this to regenerate examples")
+def test_regenerate():
+    """
+    Use this to regenerate test examples.
+    """
+    mft = MultiFileTransformer()
+    dirs = EXAMPLE_PROJECTS
+    for directory in dirs:
+        full_dir = EXAMPLE_DIR / directory
+        instructions = mft.infer_instructions(full_dir)
+        # print(yaml.dump(instructions.dict()))
+        mft.process_instructions(instructions, full_dir, test_mode=False)

--- a/tests/test_utils/test_dynamic_object.py
+++ b/tests/test_utils/test_dynamic_object.py
@@ -1,4 +1,4 @@
-import unittest
+"""Test dynamic objects."""
 
 import yaml
 from linkml_runtime import SchemaView
@@ -7,23 +7,14 @@ from linkml_map.utils.dynamic_object import dynamic_object
 from tests import FLATTENING_DATA, NORM_SCHEMA
 
 
-class DynamicObjectTestCase(unittest.TestCase):
-    """
-    Tests Dynamic Objects
-    """
-
-    def test_dynamic_object(self):
-        sv = SchemaView(NORM_SCHEMA)
-        container = yaml.safe_load(open(str(FLATTENING_DATA)))
-        dynobj = dynamic_object(container, sv, "MappingSet")
-        self.assertEqual("MappingSet", type(dynobj).__name__)
-        self.assertEqual("Entity", type(dynobj.entities["X:1"]).__name__)
-        self.assertIsInstance(dynobj.entities, dict)
-        m = dynobj.mappings[0]
-        self.assertEqual("Mapping", type(m).__name__)
-        # container["mappings"][0].subject = "U:1"
-        # dynobj = dynamic_object(container, sv, "MappingSet")
-
-
-if __name__ == "__main__":
-    unittest.main()
+def test_dynamic_object():
+    sv = SchemaView(NORM_SCHEMA)
+    container = yaml.safe_load(open(str(FLATTENING_DATA)))
+    dynobj = dynamic_object(container, sv, "MappingSet")
+    assert type(dynobj).__name__ == "MappingSet"
+    assert type(dynobj.entities["X:1"]).__name__ == "Entity"
+    assert isinstance(dynobj.entities, dict)
+    m = dynobj.mappings[0]
+    assert type(m).__name__ == "Mapping"
+    # container["mappings"][0].subject = "U:1"
+    # dynobj = dynamic_object(container, sv, "MappingSet")


### PR DESCRIPTION
This PR converts the hold-out unittest tests over to using pytest.

For the most part, I didn't make any changes to the test content. The only exception was the data model test, which I beefed up a bit with some extra assertions, since it was on the lean side...