### PR TITLE
Ruff lint

### DIFF
--- a/src/linkml_map/__init__.py
+++ b/src/linkml_map/__init__.py
@@ -1,6 +1,6 @@
 from linkml_map.transformer.object_transformer import ObjectTransformer
 
 __all__ = [
-    "Session",
     "ObjectTransformer",
+    "Session",
 ]

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -44,7 +44,7 @@ output_format_options = click.option(
 @click.option("-v", "--verbose", count=True)
 @click.option("-q", "--quiet")
 # @click.version_option(__version__)
-def main(verbose: int, quiet: bool):
+def main(verbose: int, quiet: bool) -> None:
     """CLI for linkml-map."""
     logger = logging.getLogger()
     if verbose >= 2:
@@ -79,7 +79,7 @@ def map_data(
     output,
     output_format,
     **kwargs,
-):
+) -> None:
     """
     Map data from a source schema to a target schema using a transformation specification.
 
@@ -95,10 +95,7 @@ def map_data(
         input_obj = yaml.safe_load(file)
     tr.index(input_obj, source_type)
     tr_obj = tr.map_object(input_obj, source_type)
-    if output:
-        outfile = open(output, "w", encoding="utf-8")
-    else:
-        outfile = sys.stdout
+    outfile = open(output, "w", encoding="utf-8") if output else sys.stdout
     outfile.write(yaml_dumper.dumps(tr_obj))
 
 
@@ -115,7 +112,7 @@ def compile(
     target,
     output,
     **kwargs,
-):
+) -> None:
     """
     Compiles a schema to another representation.
 
@@ -132,7 +129,8 @@ def compile(
     elif target == "markdown":
         compiler = MarkdownCompiler(**compiler_args)
     else:
-        raise NotImplementedError(f"Compiler {target} not implemented")
+        msg = f"Compiler {target} not implemented"
+        raise NotImplementedError(msg)
     tr = ObjectTransformer()
     tr.source_schemaview = SchemaView(schema)
     tr.load_transformer_specification(transformer_specification)
@@ -145,7 +143,7 @@ def compile(
 @transformer_specification_option
 @output_format_options
 @click.argument("schema")
-def derive_schema(schema, transformer_specification, output, output_format, **kwargs):
+def derive_schema(schema, transformer_specification, output, output_format, **kwargs) -> None:
     """Derive a schema from a source schema and a transformation specification.
 
     This can be thought of as "copying" the source to a target, using the transformation
@@ -166,10 +164,7 @@ def derive_schema(schema, transformer_specification, output, output_format, **kw
     mapper = SchemaMapper(transformer=tr)
     mapper.source_schemaview = SchemaView(schema)
     target_schema = mapper.derive_schema()
-    if output:
-        outfile = open(output, "w", encoding="utf-8")
-    else:
-        outfile = sys.stdout
+    outfile = open(output, "w", encoding="utf-8") if output else sys.stdout
     outfile.write(yaml_dumper.dumps(target_schema))
 
 
@@ -179,7 +174,7 @@ def derive_schema(schema, transformer_specification, output, output_format, **kw
 @output_format_options
 @click.option("--strict/--no-strict", default=True, show_default=True, help="Strict mode.")
 @click.argument("schema")
-def invert(schema, transformer_specification, output, output_format, **kwargs):
+def invert(schema, transformer_specification, output, output_format, **kwargs) -> None:
     """Invert a transformation specification.
 
     Example:
@@ -194,10 +189,7 @@ def invert(schema, transformer_specification, output, output_format, **kwargs):
         **kwargs,
     )
     inverted_spec = inverter.invert(tr.specification)
-    if output:
-        outfile = open(output, "w", encoding="utf-8")
-    else:
-        outfile = sys.stdout
+    outfile = open(output, "w", encoding="utf-8") if output else sys.stdout
     outfile.write(yaml_dumper.dumps(inverted_spec))
 
 

--- a/src/linkml_map/compiler/compiler.py
+++ b/src/linkml_map/compiler/compiler.py
@@ -14,9 +14,10 @@ For example:
 """
 
 from abc import ABC
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import Iterator, Optional
+from typing import Optional
 
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
@@ -80,7 +81,7 @@ class Compiler(ABC):
     def _compile_iterator(self, specification: TransformationSpecification) -> Iterator[str]:
         raise NotImplementedError
 
-    def derived_target_schemaview(self, specification: TransformationSpecification):
+    def derived_target_schemaview(self, specification: TransformationSpecification) -> SchemaView:
         """
         Returns a view over the target schema, including any derived classes.
         """

--- a/src/linkml_map/compiler/graphviz_compiler.py
+++ b/src/linkml_map/compiler/graphviz_compiler.py
@@ -20,10 +20,10 @@ class Record(BaseModel):
     fields: list[tuple[str, str]] = []
 
     @property
-    def id(self):
+    def id(self) -> str:
         return f"{self.source}{self.name}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"""<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
@@ -44,7 +44,7 @@ class Record(BaseModel):
 class GraphvizObject(CompiledSpecification):
     digraph: Digraph = None
 
-    def render(self, file_path: str, format="png", view=False) -> None:
+    def render(self, file_path: str, format: str = "png", view: bool = False) -> None:
         """Render a graphviz graph to a file.
         :param file_path:
         :return:

--- a/src/linkml_map/compiler/graphviz_compiler.py
+++ b/src/linkml_map/compiler/graphviz_compiler.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from graphviz import Digraph
 from linkml_runtime import SchemaView
@@ -17,7 +17,7 @@ class Record(BaseModel):
 
     name: str
     source: str
-    fields: List[Tuple[str, str]] = []
+    fields: list[tuple[str, str]] = []
 
     @property
     def id(self):
@@ -58,7 +58,7 @@ class GraphvizCompiler(Compiler):
     """
 
     def compile(
-        self, specification: TransformationSpecification, elements: Optional[List[str]] = None
+        self, specification: TransformationSpecification, elements: Optional[list[str]] = None
     ) -> GraphvizObject:
         dg = Digraph(comment="UML Class Diagram", format="png")
         dg.attr(rankdir="LR")  # Set graph direction from left to right
@@ -98,7 +98,7 @@ class GraphvizCompiler(Compiler):
                         dg.edge(f"{source_record.id}:{token}", target_id, style="dashed")
         return GraphvizObject(digraph=dg, serialization=dg.source)
 
-    def add_records(self, schemaview: SchemaView, source: str) -> List[Record]:
+    def add_records(self, schemaview: SchemaView, source: str) -> list[Record]:
         records = []
         for cn in schemaview.all_classes():
             record = Record(name=cn, source=source)

--- a/src/linkml_map/compiler/j2_based_compiler.py
+++ b/src/linkml_map/compiler/j2_based_compiler.py
@@ -24,11 +24,13 @@ class J2BasedCompiler(Compiler):
         if not template_dir:
             template_dir = TEMPLATE_DIR
         if not template_dir:
-            raise ValueError("template_dir must be set")
+            msg = "template_dir must be set"
+            raise ValueError(msg)
         loader = FileSystemLoader(template_dir)
         env = Environment(loader=loader, autoescape=True)
         if not self.template_name:
-            raise ValueError("template_name must be set")
+            msg = "template_name must be set"
+            raise ValueError(msg)
         template = env.get_template(self.template_name)
         rendered = template.render(
             spec=specification,

--- a/src/linkml_map/compiler/python_compiler.py
+++ b/src/linkml_map/compiler/python_compiler.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Iterator
 
 from jinja2 import Template
 
@@ -95,10 +95,7 @@ class PythonCompiler(Compiler):
 
     def _compiled_class_derivations_iter(self, cd: ClassDerivation) -> Iterator[str]:
         sv = self.source_schemaview
-        if cd.populated_from:
-            populated_from = cd.populated_from
-        else:
-            populated_from = cd.name
+        populated_from = cd.populated_from if cd.populated_from else cd.name
         if populated_from not in sv.all_classes():
             return
         induced_slots = {s.name: s for s in sv.class_induced_slots(populated_from)}

--- a/src/linkml_map/compiler/sql_compiler.py
+++ b/src/linkml_map/compiler/sql_compiler.py
@@ -69,7 +69,7 @@ class SQLCompiler(Compiler):
         stmt += f" FROM {cd.name}"
         compiled.serialization += f"{stmt};\n"
 
-    def compile_slot_derivation(self, sd) -> str:
+    def compile_slot_derivation(self, sd: SlotDerivation) -> str:
         expr = sd.populated_from
         if expr is None:
             expr = sd.name

--- a/src/linkml_map/functions/unit_conversion.py
+++ b/src/linkml_map/functions/unit_conversion.py
@@ -86,20 +86,20 @@ def convert_units(
     to_unit = normalize_unit(to_unit, system)
     try:
         from_unit_q = ureg.parse_units(from_unit)
-    except lark.exceptions.UnexpectedCharacters:
-        raise UndefinedUnitError(f"Cannot parse unit: {from_unit}")
-    except pint.errors.UndefinedUnitError:
-        raise UndefinedUnitError(f"Unknown source unit: {from_unit}")
+    except lark.exceptions.UnexpectedCharacters as err:
+        raise UndefinedUnitError(f"Cannot parse unit: {from_unit}") from err
+    except pint.errors.UndefinedUnitError as err:
+        raise UndefinedUnitError(f"Unknown source unit: {from_unit}") from err
     quantity = magnitude * from_unit_q
     try:
         return quantity.to(to_unit).magnitude
-    except pint.errors.UndefinedUnitError:
-        raise UndefinedUnitError(f"Unknown target unit: {from_unit}")
-    except pint.errors.DimensionalityError:
-        raise DimensionalityError(f"Cannot convert from {from_unit} to {to_unit}")
+    except pint.errors.UndefinedUnitError as err:
+        raise UndefinedUnitError(f"Unknown target unit: {from_unit}") from err
+    except pint.errors.DimensionalityError as err:
+        raise DimensionalityError(f"Cannot convert from {from_unit} to {to_unit}") from err
 
 
-@lru_cache()
+@lru_cache
 def get_unit_registry(system: Optional[UnitSystem] = None) -> Any:
     """
     Get a unit registry.

--- a/src/linkml_map/functions/unit_conversion.py
+++ b/src/linkml_map/functions/unit_conversion.py
@@ -87,16 +87,20 @@ def convert_units(
     try:
         from_unit_q = ureg.parse_units(from_unit)
     except lark.exceptions.UnexpectedCharacters as err:
-        raise UndefinedUnitError(f"Cannot parse unit: {from_unit}") from err
+        msg = f"Cannot parse unit: {from_unit}"
+        raise UndefinedUnitError(msg) from err
     except pint.errors.UndefinedUnitError as err:
-        raise UndefinedUnitError(f"Unknown source unit: {from_unit}") from err
+        msg = f"Unknown source unit: {from_unit}"
+        raise UndefinedUnitError(msg) from err
     quantity = magnitude * from_unit_q
     try:
         return quantity.to(to_unit).magnitude
     except pint.errors.UndefinedUnitError as err:
-        raise UndefinedUnitError(f"Unknown target unit: {from_unit}") from err
+        msg = f"Unknown target unit: {from_unit}"
+        raise UndefinedUnitError(msg) from err
     except pint.errors.DimensionalityError as err:
-        raise DimensionalityError(f"Cannot convert from {from_unit} to {to_unit}") from err
+        msg = f"Cannot convert from {from_unit} to {to_unit}"
+        raise DimensionalityError(msg) from err
 
 
 @lru_cache
@@ -140,7 +144,8 @@ def get_unit_registry(system: Optional[UnitSystem] = None) -> Any:
     if system.value in dir(ureg.sys):
         ureg.default_system = system.value
         return ureg
-    raise NotImplementedError(f"Unknown unit system: {system}")
+    msg = f"Unknown unit system: {system}"
+    raise NotImplementedError(msg)
 
 
 def normalize_unit(unit: str, system: Optional[UnitSystem] = None) -> str:
@@ -149,9 +154,11 @@ def normalize_unit(unit: str, system: Optional[UnitSystem] = None) -> str:
     if system == UnitSystem.UCUM:
         try:
             return str(get_unit_registry(system).from_ucum(unit))
-        except pint.errors.UndefinedUnitError:
-            raise UndefinedUnitError(f"Unknown unit: {unit}")
-        except lark.exceptions.UnexpectedCharacters:
-            raise UndefinedUnitError(f"Cannot parse unit: {unit}")
+        except pint.errors.UndefinedUnitError as err:
+            msg = f"Unknown unit: {unit}"
+            raise UndefinedUnitError(msg) from err
+        except lark.exceptions.UnexpectedCharacters as err:
+            msg = f"Cannot parse unit: {unit}"
+            raise UndefinedUnitError(msg) from err
     else:
         return unit

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -5,7 +5,7 @@ from linkml_map.datamodel.transformer_model import TransformationSpecification
 
 def induce_missing_values(
     specification: TransformationSpecification, source_schemaview: SchemaView
-):
+) -> None:
     """
     Infer missing values in a specification.
 

--- a/src/linkml_map/inference/inverter.py
+++ b/src/linkml_map/inference/inverter.py
@@ -40,7 +40,7 @@ class TransformationSpecificationInverter:
 
     strict: bool = field(default=True)
 
-    def invert(self, spec: TransformationSpecification):
+    def invert(self, spec: TransformationSpecification) -> TransformationSpecification:
         """
         Invert a transformation specification.
 
@@ -57,7 +57,9 @@ class TransformationSpecificationInverter:
             inverted_spec.enum_derivations[inverted_ed.name] = inverted_ed
         return inverted_spec
 
-    def invert_class_derivation(self, cd: ClassDerivation, spec: TransformationSpecification):
+    def invert_class_derivation(
+        self, cd: ClassDerivation, spec: TransformationSpecification
+    ) -> ClassDerivation:
         """
         Invert a class derivation.
 
@@ -72,12 +74,13 @@ class TransformationSpecificationInverter:
             inverted_sd = self.invert_slot_derivation(sd, cd, spec)
             if inverted_sd:
                 inverted_cd.slot_derivations[inverted_sd.name] = inverted_sd
-            else:
-                if self.strict:
-                    raise NonInvertibleSpecification(f"Cannot invert slot derivation: {sd.name}")
+            elif self.strict:
+                raise NonInvertibleSpecification(f"Cannot invert slot derivation: {sd.name}")
         return inverted_cd
 
-    def invert_enum_derivation(self, ed: EnumDerivation, spec: TransformationSpecification):
+    def invert_enum_derivation(
+        self, ed: EnumDerivation, spec: TransformationSpecification
+    ) -> EnumDerivation:
         """
         Invert an enum derivation.
 
@@ -145,14 +148,13 @@ class TransformationSpecificationInverter:
         if source_slot and source_slot.multivalued:
             if source_slot.inlined_as_list:
                 inverted_sd.cast_collection_as = CollectionType.MultiValuedList
-            elif source_slot.inlined:
-                if source_slot.range in self.source_schemaview.all_classes():
-                    id_slot = self.source_schemaview.get_identifier_slot(
-                        source_slot.range, use_key=True
-                    )
-                    if id_slot:
-                        inverted_sd.cast_collection_as = CollectionType.MultiValuedDict
-                        inverted_sd.dictionary_key = id_slot.name
+            elif source_slot.inlined and source_slot.range in self.source_schemaview.all_classes():
+                id_slot = self.source_schemaview.get_identifier_slot(
+                    source_slot.range, use_key=True
+                )
+                if id_slot:
+                    inverted_sd.cast_collection_as = CollectionType.MultiValuedDict
+                    inverted_sd.dictionary_key = id_slot.name
         if sd.unit_conversion:
             source_slot = self.source_schemaview.induced_slot(sd.populated_from, source_cls_name)
             target_unit = None

--- a/src/linkml_map/inference/inverter.py
+++ b/src/linkml_map/inference/inverter.py
@@ -19,7 +19,7 @@ from linkml_map.datamodel.transformer_model import (
 logger = logging.getLogger(__name__)
 
 
-class NonInvertibleSpecification(ValueError):
+class NonInvertibleSpecificationError(ValueError):
     pass
 
 
@@ -75,7 +75,8 @@ class TransformationSpecificationInverter:
             if inverted_sd:
                 inverted_cd.slot_derivations[inverted_sd.name] = inverted_sd
             elif self.strict:
-                raise NonInvertibleSpecification(f"Cannot invert slot derivation: {sd.name}")
+                msg = f"Cannot invert slot derivation: {sd.name}"
+                raise NonInvertibleSpecificationError(msg)
         return inverted_cd
 
     def invert_enum_derivation(
@@ -92,7 +93,8 @@ class TransformationSpecificationInverter:
             name=ed.populated_from if ed.populated_from else ed.name, populated_from=ed.name
         )
         if inverted_ed.expr:
-            raise NonInvertibleSpecification("TODO: invert enum derivation with expression")
+            msg = "TODO: invert enum derivation with expression"
+            raise NonInvertibleSpecificationError(msg)
         for pv_deriv in ed.permissible_value_derivations.values():
             inverted_pv_deriv = PermissibleValueDerivation(
                 name=pv_deriv.populated_from if pv_deriv.populated_from else pv_deriv.name,
@@ -120,13 +122,12 @@ class TransformationSpecificationInverter:
                 if not self.strict:
                     return None
                 # TODO: add logic for reversible expressions
-                raise NonInvertibleSpecification(
-                    f"Cannot invert expression {sd.expr} in slot derivation: {sd.name}"
-                )
+                msg = f"Cannot invert expression {sd.expr} in slot derivation: {sd.name}"
+                raise NonInvertibleSpecificationError(msg)
         if not populated_from:
             # use defaults. TODO: decide on semantics of defaults
             populated_from = sd.name
-            # raise NonInvertibleSpecification(f"No populate_from or expr in slot derivation: {sd.name}")
+            # raise NonInvertibleSpecificationError(f"No populate_from or expr in slot derivation: {sd.name}")
         inverted_sd = SlotDerivation(name=populated_from, populated_from=sd.name)
         # source_cls_name = spec.class_derivations[cd.populated_from].name
         source_cls_name = cd.populated_from

--- a/src/linkml_map/session.py
+++ b/src/linkml_map/session.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import yaml
+from graphviz import Digraph
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition
@@ -43,7 +44,7 @@ class Session:
 
     def set_transformer_specification(
         self, specification: Optional[Union[TransformationSpecification, dict, str, Path]] = None
-    ):
+    ) -> None:
         if isinstance(specification, Path):
             specification = str(specification)
         if isinstance(specification, TransformationSpecification):
@@ -63,7 +64,9 @@ class Session:
                 obj = yaml.safe_load(open(specification))
             self.set_transformer_specification(obj)
 
-    def set_source_schema(self, schema: Union[str, Path, dict, SchemaView, SchemaDefinition]):
+    def set_source_schema(
+        self, schema: Union[str, Path, dict, SchemaView, SchemaDefinition]
+    ) -> None:
         """
         Sets the schema from a path or SchemaView object.
         """
@@ -78,15 +81,16 @@ class Session:
         elif isinstance(schema, SchemaDefinition):
             sv = SchemaView(schema)
         else:
-            raise ValueError(f"Unsupported schema type: {type(schema)}")
+            msg = f"Unsupported schema type: {type(schema)}"
+            raise ValueError(msg)
         self.source_schemaview = sv
         self._target_schema = None
 
     def set_transformer(
         self,
         transformer: Optional[Union[Transformer, type[Transformer]]],
-        **kwargs,
-    ):
+        **kwargs: dict[str, Any],
+    ) -> None:
         if isinstance(transformer, type):
             transformer = transformer()
         transformer.specification = self.transformer_specification
@@ -97,7 +101,7 @@ class Session:
         transformer: Optional[
             Union[ObjectTransformer, TransformationSpecification, dict, str, Path]
         ] = None,
-    ):
+    ) -> None:
         if transformer is None:
             if self.object_transformer is not None:
                 logger.info("No change")
@@ -128,14 +132,15 @@ class Session:
             self._target_schemaview = SchemaView(yaml_dumper.dumps(self.target_schema))
         return self._target_schemaview
 
-    def transform(self, obj: dict, **kwargs) -> dict:
+    def transform(self, obj: dict, **kwargs: dict[str, Any]) -> dict:
         if self.object_transformer is None:
-            raise ValueError("No transformer specified")
+            msg = "No transformer specified"
+            raise ValueError(msg)
         if not self.object_transformer.source_schemaview:
             self.object_transformer.source_schemaview = self.source_schemaview
         return self.object_transformer.map_object(obj, **kwargs)
 
-    def reverse_transform(self, obj: dict, **kwargs) -> dict:
+    def reverse_transform(self, obj: dict, **kwargs: dict[str, Any]) -> dict:
         inv_spec = self.invert()
         reverse_transformer = ObjectTransformer()
         reverse_transformer.specification = inv_spec
@@ -155,7 +160,7 @@ class Session:
             raise NotImplementedError
         return inv_spec
 
-    def graphviz(self, **kwargs) -> Any:
+    def graphviz(self, **kwargs: dict[str, Any]) -> Digraph:
         """
         Return a graphviz representation of the schema.
         """

--- a/src/linkml_map/session.py
+++ b/src/linkml_map/session.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import yaml
 from linkml_runtime import SchemaView
@@ -84,10 +84,10 @@ class Session:
 
     def set_transformer(
         self,
-        transformer: Optional[Union[Transformer, Type[Transformer]]],
+        transformer: Optional[Union[Transformer, type[Transformer]]],
         **kwargs,
     ):
-        if isinstance(transformer, Type):
+        if isinstance(transformer, type):
             transformer = transformer()
         transformer.specification = self.transformer_specification
         self.transformer = transformer
@@ -101,10 +101,9 @@ class Session:
         if transformer is None:
             if self.object_transformer is not None:
                 logger.info("No change")
-                return
             else:
                 logger.warning("No transformer specified")
-                return
+            return
         if transformer is not None:
             if isinstance(transformer, ObjectTransformer):
                 self.object_transformer = transformer
@@ -143,7 +142,7 @@ class Session:
         reverse_transformer.source_schemaview = SchemaView(yaml_dumper.dumps(self.target_schema))
         return reverse_transformer.map_object(obj, **kwargs)
 
-    def invert(self, in_place=False) -> TransformationSpecification:
+    def invert(self, in_place: bool = False) -> TransformationSpecification:
         """
         Invert the transformer specification.
         """

--- a/src/linkml_map/transformer/duckdb_transformer.py
+++ b/src/linkml_map/transformer/duckdb_transformer.py
@@ -1,13 +1,13 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from duckdb import DuckDBPyConnection
 
 from linkml_map.compiler.sql_compiler import SQLCompiler
 from linkml_map.transformer.transformer import OBJECT_TYPE, Transformer
 
-DICT_OBJ = Dict[str, Any]
+DICT_OBJ = dict[str, Any]
 DATABASE = Union[str, DuckDBPyConnection]
 
 
@@ -23,8 +23,8 @@ class DuckDBTransformer(Transformer):
     def map_object(
         self,
         source_obj: OBJECT_TYPE,
-        source_type: str = None,
-        target_type: str = None,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
         **kwargs,
     ) -> OBJECT_TYPE:
         """

--- a/src/linkml_map/transformer/duckdb_transformer.py
+++ b/src/linkml_map/transformer/duckdb_transformer.py
@@ -25,7 +25,7 @@ class DuckDBTransformer(Transformer):
         source_obj: OBJECT_TYPE,
         source_type: Optional[str] = None,
         target_type: Optional[str] = None,
-        **kwargs,
+        **kwargs: dict[str, Any],
     ) -> OBJECT_TYPE:
         """
         Transform a source object into a target object.
@@ -36,10 +36,14 @@ class DuckDBTransformer(Transformer):
         :return: transformed data, either as type target_type or a dictionary
         """
         # sv = self.source_schemaview
-        raise NotImplementedError("DuckDBTransformer.transform")
+        msg = "DuckDBTransformer.transform"
+        raise NotImplementedError(msg)
 
     def map_database(
-        self, source_database: DATABASE, target_database: Optional[DATABASE] = None, **kwargs
+        self,
+        source_database: DATABASE,
+        target_database: Optional[DATABASE] = None,
+        **kwargs: dict[str, Any],
     ) -> OBJECT_TYPE:
         """
         Transform source resource.
@@ -65,6 +69,7 @@ class DuckDBTransformer(Transformer):
         source_connection.sql(sql_compiler.create_ddl(self.source_schemaview))
         target_connection.sql(sql_compiler.create_ddl(self.target_schemaview))
         if not self.specification:
-            raise ValueError("No specification provided.")
+            msg = "No specification provided."
+            raise ValueError(msg)
         compiled = sql_compiler.compile(self.specification)
         source_connection.execute(compiled.serialization)

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -40,7 +40,7 @@ class Bindings(Mapping):
         source_type: str,
         sv: SchemaView,
         bindings: dict,
-    ):
+    ) -> None:
         self.object_transformer: ObjectTransformer = object_transformer
         self.source_obj: OBJECT_TYPE = source_obj
         self.source_obj_typed: OBJECT_TYPE = source_obj_typed
@@ -106,9 +106,10 @@ class Bindings(Mapping):
 
         return self.bindings.get(name)
 
-    def __setitem__(self, name: Any, value: Any):
+    def __setitem__(self, name: Any, value: Any) -> None:
         del name, value
-        raise RuntimeError(f"__setitem__ not allowed on class {self.__class__.__name__}")
+        msg = f"__setitem__ not allowed on class {self.__class__.__name__}"
+        raise RuntimeError(msg)
 
 
 @dataclass
@@ -121,7 +122,7 @@ class ObjectTransformer(Transformer):
 
     object_index: ObjectIndex = None
 
-    def index(self, source_obj: Any, target: Optional[str] = None):
+    def index(self, source_obj: Any, target: Optional[str] = None) -> None:
         """
         Create an index over a container object.
 
@@ -134,7 +135,8 @@ class ObjectTransformer(Transformer):
                     c.name for c in self.source_schemaview.all_classes().values() if c.tree_root
                 ]
             if target is None:
-                raise ValueError(f"target must be passed if source_obj is dict: {source_obj}")
+                msg = f"target must be passed if source_obj is dict: {source_obj}"
+                raise ValueError(msg)
             source_obj_typed = dynamic_object(source_obj, self.source_schemaview, target)
             self.object_index = ObjectIndex(source_obj_typed, schemaview=self.source_schemaview)
         else:
@@ -163,12 +165,14 @@ class ObjectTransformer(Transformer):
             if len(source_types) == 1:
                 source_type = source_types[0]
             elif len(source_types) > 1:
-                raise ValueError("No source type specified and multiple root classes found")
+                msg = "No source type specified and multiple root classes found"
+                raise ValueError(msg)
             elif len(source_types) == 0:
                 if len(sv.all_classes()) == 1:
                     source_type = list(sv.all_classes().keys())[0]
                 else:
-                    raise ValueError("No source type specified and no root classes found")
+                    msg = "No source type specified and no root classes found"
+                    raise ValueError(msg)
 
         if source_type in sv.all_types():
             if target_type:
@@ -217,9 +221,10 @@ class ObjectTransformer(Transformer):
 
                 try:
                     v = eval_expr_with_mapping(slot_derivation.expr, bindings)
-                except Exception:
+                except Exception as err:
                     if not self.unrestricted_eval:
-                        raise RuntimeError(f"Expression not in safe subset: {slot_derivation.expr}")
+                        msg = f"Expression not in safe subset: {slot_derivation.expr}"
+                        raise RuntimeError(msg) from err
                     ctxt_obj, _ = bindings.get_ctxt_obj_and_dict()
                     aeval = Interpreter(usersyms={"src": ctxt_obj, "target": None})
                     aeval(slot_derivation.expr)
@@ -234,7 +239,8 @@ class ObjectTransformer(Transformer):
                 vmap = {s: source_obj.get(s, None) for s in slot_derivation.sources}
                 vmap = {k: v for k, v in vmap.items() if v is not None}
                 if len(vmap.keys()) > 1:
-                    raise ValueError(f"Multiple sources for {slot_derivation.name}: {vmap}")
+                    msg = f"Multiple sources for {slot_derivation.name}: {vmap}"
+                    raise ValueError(msg)
                 if len(vmap.keys()) == 1:
                     v = list(vmap.values())[0]
                     source_class_slot_name = list(vmap.keys())[0]
@@ -314,14 +320,12 @@ class ObjectTransformer(Transformer):
             if uc.source_unit_slot:
                 from_unit = curr_v.get(uc.source_unit_slot, None)
                 if from_unit is None:
-                    raise ValueError(
-                        f"Could not determine unit from {curr_v} using {uc.source_unit_slot}"
-                    )
+                    msg = f"Could not determine unit from {curr_v} using {uc.source_unit_slot}"
+                    raise ValueError(msg)
                 magnitude = curr_v.get(uc.source_magnitude_slot, None)
                 if magnitude is None:
-                    raise ValueError(
-                        f"Could not determine magnitude from {curr_v} using {uc.source_magnitude_slot}"
-                    )
+                    msg = f"Could not determine magnitude from {curr_v} using {uc.source_magnitude_slot}"
+                    raise ValueError(msg)
             else:
                 if slot.unit.ucum_code:
                     from_unit = slot.unit.ucum_code
@@ -337,10 +341,12 @@ class ObjectTransformer(Transformer):
                     elif slot.unit.descriptive_name:
                         from_unit = slot.unit.descriptive_name
                     else:
-                        raise NotImplementedError(f"Cannot determine unit system for {slot.unit}")
+                        msg = f"Cannot determine unit system for {slot.unit}"
+                        raise NotImplementedError(msg)
                 magnitude = curr_v
             if not from_unit:
-                raise ValueError(f"Could not determine from_unit for {slot_derivation}")
+                msg = f"Could not determine from_unit for {slot_derivation}"
+                raise ValueError(msg)
             if not to_unit:
                 to_unit = from_unit
                 # raise ValueError(f"Could not determine to_unit for {slot_derivation}")
@@ -368,10 +374,13 @@ class ObjectTransformer(Transformer):
                     return json.dumps(vs)
                 if stringification.syntax == SerializationSyntaxType.YAML:
                     return yaml.dump(vs, default_flow_style=True).strip()
-                raise ValueError(f"Unknown syntax: {stringification.syntax}")
-            raise ValueError(f"Cannot convert multivalued to single valued: {vs}; no delimiter")
+                msg = f"Unknown syntax: {stringification.syntax}"
+                raise ValueError(msg)
+            msg = f"Cannot convert multivalued to single valued: {vs}; no delimiter"
+            raise ValueError(msg)
         if len(vs) > 1:
-            raise ValueError(f"Cannot coerce multiple values {vs}")
+            msg = f"Cannot coerce multiple values {vs}"
+            raise ValueError(msg)
         if len(vs) == 0:
             return None
         return vs[0]
@@ -391,9 +400,11 @@ class ObjectTransformer(Transformer):
                 elif syntax == SerializationSyntaxType.YAML:
                     vs = yaml.safe_load(v)
                 else:
-                    raise ValueError(f"Unknown syntax: {syntax}")
+                    msg = f"Unknown syntax: {syntax}"
+                    raise ValueError(msg)
             else:
-                raise ValueError(f"Cannot convert single valued to multivalued: {v}; no delimiter")
+                msg = f"Cannot convert single valued to multivalued: {v}; no delimiter"
+                raise ValueError(msg)
             return vs
         return [v]
 
@@ -413,7 +424,8 @@ class ObjectTransformer(Transformer):
         :rtype: Union[YAMLRoot, BaseModel]
         """
         if not target_class:
-            raise ValueError("No target_class specified for transform_object")
+            msg = "No target_class specified for transform_object"
+            raise ValueError(msg)
 
         source_type = type(source_obj)
         source_type_name = source_type.__name__

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -64,7 +64,7 @@ class Transformer(ABC):
     _curie_converter: Converter = None
 
     def map_object(
-        self, obj: OBJECT_TYPE, source_type: Optional[str] = None, **kwargs
+        self, obj: OBJECT_TYPE, source_type: Optional[str] = None, **kwargs: dict[str, Any]
     ) -> OBJECT_TYPE:
         """
         Transform source object into an instance of the target class.
@@ -76,7 +76,7 @@ class Transformer(ABC):
         raise NotImplementedError
 
     def map_database(
-        self, source_database: Any, target_database: Optional[Any] = None, **kwargs
+        self, source_database: Any, target_database: Optional[Any] = None, **kwargs: dict[str, Any]
     ) -> OBJECT_TYPE:
         """
         Transform source resource.
@@ -88,7 +88,7 @@ class Transformer(ABC):
         """
         raise NotImplementedError
 
-    def load_source_schema(self, path: Union[str, Path, dict]):
+    def load_source_schema(self, path: Union[str, Path, dict]) -> None:
         """
         Sets source_schemaview from a schema path.
 
@@ -99,7 +99,7 @@ class Transformer(ABC):
             path = str(path)
         self.source_schemaview = SchemaView(path)
 
-    def load_transformer_specification(self, path: Union[str, Path]):
+    def load_transformer_specification(self, path: Union[str, Path]) -> None:
         """
         Sets specification from a schema path.
 
@@ -117,7 +117,7 @@ class Transformer(ABC):
             obj = normalizer.normalize(obj)
             self.specification = TransformationSpecification(**obj)
 
-    def create_transformer_specification(self, obj: dict[str, Any]):
+    def create_transformer_specification(self, obj: dict[str, Any]) -> None:
         """
         Creates specification from a dict.
 
@@ -152,9 +152,8 @@ class Transformer(ABC):
         ]
         logger.debug(f"Target class derivations={matching_tgt_class_derivs}")
         if len(matching_tgt_class_derivs) != 1:
-            raise ValueError(
-                f"Could not find class derivation for {target_class_name} (results={len(matching_tgt_class_derivs)})"
-            )
+            msg = f"Could not find class derivation for {target_class_name} (results={len(matching_tgt_class_derivs)})"
+            raise ValueError(msg)
         cd = matching_tgt_class_derivs[0]
         ancmap = self._class_derivation_ancestors(cd)
         if ancmap:
@@ -195,7 +194,8 @@ class Transformer(ABC):
         ]
         logger.debug(f"Target enum derivations={matching_tgt_enum_derivs}")
         if len(matching_tgt_enum_derivs) != 1:
-            raise ValueError(f"Could not find what to derive from a source {target_enum_name}")
+            msg = f"Could not find what to derive from a source {target_enum_name}"
+            raise ValueError(msg)
         return matching_tgt_enum_derivs[0]
 
     def _is_coerce_to_multivalued(

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -8,7 +8,7 @@ from abc import ABC
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import yaml
 from curies import Converter
@@ -30,7 +30,7 @@ from linkml_map.inference.inference import induce_missing_values
 logger = logging.getLogger(__name__)
 
 
-OBJECT_TYPE = Union[Dict[str, Any], BaseModel, YAMLRoot]
+OBJECT_TYPE = Union[dict[str, Any], BaseModel, YAMLRoot]
 """An object can be a plain python dict, a pydantic object, or a linkml YAMLRoot"""
 
 
@@ -63,7 +63,9 @@ class Transformer(ABC):
 
     _curie_converter: Converter = None
 
-    def map_object(self, obj: OBJECT_TYPE, source_type: str = None, **kwargs) -> OBJECT_TYPE:
+    def map_object(
+        self, obj: OBJECT_TYPE, source_type: Optional[str] = None, **kwargs
+    ) -> OBJECT_TYPE:
         """
         Transform source object into an instance of the target class.
 
@@ -115,7 +117,7 @@ class Transformer(ABC):
             obj = normalizer.normalize(obj)
             self.specification = TransformationSpecification(**obj)
 
-    def create_transformer_specification(self, obj: Dict[str, Any]):
+    def create_transformer_specification(self, obj: dict[str, Any]):
         """
         Creates specification from a dict.
 
@@ -165,12 +167,11 @@ class Transformer(ABC):
                             curr_v.extend(v)
                         elif isinstance(curr_v, dict):
                             curr_v.update({**v, **curr_v})
-                        else:
-                            if curr_v is None:
-                                setattr(cd, k, v)
+                        elif curr_v is None:
+                            setattr(cd, k, v)
         return cd
 
-    def _class_derivation_ancestors(self, cd: ClassDerivation) -> Dict[str, ClassDerivation]:
+    def _class_derivation_ancestors(self, cd: ClassDerivation) -> dict[str, ClassDerivation]:
         """
         Returns a map of all class derivations that are ancestors of the given class derivation.
         :param cd:
@@ -199,7 +200,7 @@ class Transformer(ABC):
 
     def _is_coerce_to_multivalued(
         self, slot_derivation: SlotDerivation, class_derivation: ClassDerivation
-    ):
+    ) -> bool:
         cast_as = slot_derivation.cast_collection_as
         if cast_as and cast_as in [
             CollectionType.MultiValued,
@@ -218,7 +219,7 @@ class Transformer(ABC):
 
     def _is_coerce_to_singlevalued(
         self, slot_derivation: SlotDerivation, class_derivation: ClassDerivation
-    ):
+    ) -> bool:
         cast_as = slot_derivation.cast_collection_as
         if cast_as and cast_as == CollectionType(CollectionType.SingleValued):
             return True
@@ -244,7 +245,7 @@ class Transformer(ABC):
             "string": str,
             "boolean": bool,
         }
-        cls = cmap.get(target_range, None)
+        cls = cmap.get(target_range)
         if not cls:
             logger.warning(f"Unknown target range {target_range}")
             return v

--- a/src/linkml_map/utils/dynamic_object.py
+++ b/src/linkml_map/utils/dynamic_object.py
@@ -4,7 +4,7 @@ from linkml_runtime import SchemaView
 
 
 class DynObj:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: dict[str, Any]) -> None:
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/src/linkml_map/utils/multi_file_transformer.py
+++ b/src/linkml_map/utils/multi_file_transformer.py
@@ -4,9 +4,10 @@ import glob
 import logging
 import os
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Mapping, Optional, Union
+from typing import Optional, Union
 
 import yaml
 from linkml_runtime import SchemaView
@@ -29,12 +30,12 @@ class Transformation(BaseModel):
     source_schema: str = None
     target_schema: str = None
     transformation_specification: str = None
-    steps: List[Step] = None
+    steps: list[Step] = None
 
 
 class Instructions(BaseModel):
     description: Optional[str] = None
-    transformations: List[Transformation] = []
+    transformations: list[Transformation] = []
 
 
 @dataclass
@@ -57,10 +58,10 @@ class MultiFileTransformer:
     target_schema_directory_base: str = field(default_factory=lambda: "target")
     target_data_directory_base: str = field(default_factory=lambda: "output")
 
-    input_formats: Optional[List[str]] = field(default_factory=lambda: ["yaml"])
+    input_formats: Optional[list[str]] = field(default_factory=lambda: ["yaml"])
     """Expected formats for input data"""
 
-    output_formats: Optional[List[str]] = field(default_factory=lambda: ["yaml"])
+    output_formats: Optional[list[str]] = field(default_factory=lambda: ["yaml"])
 
     prefix_map: Optional[Mapping[str, str]] = None
     """Custom prefix map, for emitting RDF/turtle."""
@@ -203,8 +204,7 @@ class MultiFileTransformer:
                                     raise ValueError(
                                         f"Output different than expected: {compare_obj}"
                                     )
-                                else:
-                                    logging.warning(f"Different: {compare_obj}")
+                                logging.warning(f"Different: {compare_obj}")
                     with open(str(out_path), "w", encoding="utf-8") as f:
                         yaml_str = yaml.dump(target_obj, sort_keys=False)
                         f.write(yaml_str)

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -1,7 +1,6 @@
 """Tests all command-line subcommands."""
 
 import pytest
-
 import yaml
 from click.testing import CliRunner
 from linkml_runtime import SchemaView
@@ -58,7 +57,7 @@ def test_map_data(runner: CliRunner) -> None:
     assert result.exit_code == 0
     out = result.stdout
     tr_data = yaml.safe_load(out)
-    assert "fred bloggs" == tr_data["agents"][0]["label"]
+    assert tr_data["agents"][0]["label"] == "fred bloggs"
 
 
 def test_map_data2(runner: CliRunner) -> None:

--- a/tests/test_compliance/test_compliance_suite.py
+++ b/tests/test_compliance/test_compliance_suite.py
@@ -22,7 +22,7 @@ import re
 from dataclasses import dataclass
 from datetime import date
 from types import ModuleType
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import pytest
 from deepdiff import DeepDiff
@@ -100,7 +100,9 @@ def build_transformer(**kwargs) -> TransformationSpecification:
     return mapper.specification
 
 
-def create_compilers(spec: TransformationSpecification, expected_map: [Dict[ModuleType, str]]):
+def create_compilers(
+    spec: TransformationSpecification, expected_map: [dict[ModuleType, str]]
+) -> None:
     """
     Test compilation of transformation specifications to other languages.
 
@@ -128,8 +130,8 @@ class State:
 
 def map_object(
     spec: TransformationSpecification,
-    source_object: Dict[str, Any],
-    expected_target_object: Dict[str, Any],
+    source_object: dict[str, Any],
+    expected_target_object: dict[str, Any],
     source_sv: SchemaView,
     invertible: bool = False,
     index: bool = False,
@@ -493,19 +495,18 @@ def test_expr(invocation_tracker, expr, source_object, target_value):
                     r = {"range": r}
                 classes[typ]["attributes"][k1] = r
             return typ
-        elif isinstance(v, list):
+        if isinstance(v, list):
             r = infer_range(v[0])
             return {"range": r, "multivalued": True}
-        elif isinstance(v, int):
+        if isinstance(v, int):
             return "integer"
-        elif isinstance(v, float):
+        if isinstance(v, float):
             return "float"
-        elif isinstance(v, bool):
+        if isinstance(v, bool):
             return "boolean"
-        elif isinstance(v, str):
+        if isinstance(v, str):
             return "string"
-        else:
-            raise ValueError(f"Unknown type {type(v)}")
+        raise ValueError(f"Unknown type {type(v)}")
 
     infer_range(source_object, typ="C")
     schema = build_schema("expr", classes=classes)
@@ -1145,11 +1146,10 @@ def test_inheritance(invocation_tracker, is_a, flatten):
             "expr": "s2 + 1",
         }
         del cds["D"]
+    elif is_a:
+        cds["C"]["is_a"] = "D"
     else:
-        if is_a:
-            cds["C"]["is_a"] = "D"
-        else:
-            cds["C"]["mixins"] = ["D"]
+        cds["C"]["mixins"] = ["D"]
     spec = build_transformer(class_derivations=cds)
     source_object = {"s1": 1, "s2": 2}
     target_object = {"s1": 2, "s2": 3}

--- a/tests/test_schema_mapper/test_schema_mapper.py
+++ b/tests/test_schema_mapper/test_schema_mapper.py
@@ -70,7 +70,7 @@ def test_null_specification(mapper):
     """
     specification = TransformationSpecification(id="test")
     target_schema = mapper.derive_schema(specification)
-    assert [] == list(target_schema.classes.values())
+    assert list(target_schema.classes.values()) == []
 
 
 def test_null_specification_and_source():
@@ -83,7 +83,7 @@ def test_null_specification_and_source():
     tr.source_schemaview = SchemaView(SCHEMA1)
     specification = TransformationSpecification(id="test")
     target_schema = tr.derive_schema(specification)
-    assert [] == list(target_schema.classes.values())
+    assert list(target_schema.classes.values()) == []
 
 
 def test_definition_in_derivation():
@@ -121,9 +121,9 @@ def test_definition_in_derivation():
 
     thing = target_schema.classes["Thing"]
     atts = thing.attributes
-    assert ["id"] == list(atts.keys())
+    assert list(atts.keys()) == ["id"]
     id_att = atts["id"]
-    assert "uriorcurie" == id_att.range
+    assert id_att.range == "uriorcurie"
     assert id_att.identifier
     agent = target_schema.classes["Agent"]
     assert agent.is_a == "Thing"
@@ -141,7 +141,7 @@ def test_derive_partial(mapper):
         specification.class_derivations[derivation.name] = derivation
     target_schema = mapper.derive_schema(specification)
     print(yaml_dumper.dumps(target_schema))
-    assert ["Agent"] == list(target_schema.classes.keys())
+    assert list(target_schema.classes.keys()) == ["Agent"]
 
 
 def test_rewire():
@@ -165,7 +165,7 @@ def test_rewire():
         id="test",
     )
     target_schema = tr.derive_schema(specification)
-    assert [] == list(target_schema.classes.values())
+    assert list(target_schema.classes.values()) == []
     specification = TransformationSpecification(
         id="test",
         class_derivations={
@@ -181,14 +181,14 @@ def test_rewire():
         },
     )
     target_schema = tr.derive_schema(specification)
-    assert ["TrEmployee"] == list(target_schema.classes.keys())
+    assert list(target_schema.classes.keys()) == ["TrEmployee"]
     emp = target_schema.classes["TrEmployee"]
-    assert ["tr_salary"] == list(emp.attributes.keys())
+    assert list(emp.attributes.keys()) == ["tr_salary"]
     specification.class_derivations["TrEmployee"].is_a = "Person"
     target_schema = tr.derive_schema(specification)
-    assert ["TrEmployee"] == list(target_schema.classes.keys())
+    assert list(target_schema.classes.keys()) == ["TrEmployee"]
     emp = target_schema.classes["TrEmployee"]
-    assert ["tr_salary"] == list(emp.attributes.keys())
+    assert list(emp.attributes.keys()) == ["tr_salary"]
     # self.assertEqual("Person", emp.is_a)
 
 
@@ -218,11 +218,9 @@ def test_partial_copy_specification(mapper):
         specification.class_derivations[derivation.name] = derivation
     target_schema = mapper.derive_schema(specification)
     # classes must be the same with addition
-    for schema_class in source_schema.classes.keys():
-        assert schema_class in target_schema.classes.keys(), (
-            f"Class '{schema_class}' is missing in target"
-        )
-    assert "Agent" in target_schema.classes.keys(), "Derived class 'Agent' is missing in target"
+    for schema_class in source_schema.classes:
+        assert schema_class in target_schema.classes, f"Class '{schema_class}' is missing in target"
+    assert "Agent" in target_schema.classes, "Derived class 'Agent' is missing in target"
     # slots and enums must be exactly the same
     assert yaml_dumper.dumps(source_schema.slots) == yaml_dumper.dumps(target_schema.slots)
     assert yaml_dumper.dumps(source_schema.enums) == yaml_dumper.dumps(target_schema.enums)
@@ -241,11 +239,9 @@ def test_full_copy_class(mapper):
         specification.class_derivations[derivation.name] = derivation
     target_schema = mapper.derive_schema(specification)
     # classes must be the same with addition
-    for schema_class in source_schema.classes.keys():
-        assert schema_class in target_schema.classes.keys(), (
-            f"Class '{schema_class}' is missing in target"
-        )
-    assert "Agent" in target_schema.classes.keys(), "Derived class 'Agent' is missing in target"
+    for schema_class in source_schema.classes:
+        assert schema_class in target_schema.classes, f"Class '{schema_class}' is missing in target"
+    assert "Agent" in target_schema.classes, "Derived class 'Agent' is missing in target"
     assert yaml_dumper.dumps(source_schema.classes["Person"].slots) == yaml_dumper.dumps(
         target_schema.classes["Agent"].slots
     )
@@ -271,16 +267,16 @@ def test_copy_blacklisting(mapper):
         specification.class_derivations[derivation.name] = derivation
     target_schema = mapper.derive_schema(specification)
     # classes must be the same with addition
-    for schema_class in source_schema.classes.keys():
+    for schema_class in source_schema.classes:
         if schema_class in blacklist:
-            assert schema_class not in target_schema.classes.keys(), (
+            assert schema_class not in target_schema.classes, (
                 f"Class '{schema_class}' is missing in target"
             )
         else:
-            assert schema_class in target_schema.classes.keys(), (
+            assert schema_class in target_schema.classes, (
                 f"Class '{schema_class}' is missing in target"
             )
-    assert "Agent" in target_schema.classes.keys(), "Derived class 'Agent' is missing in target"
+    assert "Agent" in target_schema.classes, "Derived class 'Agent' is missing in target"
 
     # slots and enums must be exactly the same
     assert yaml_dumper.dumps(source_schema.slots) == yaml_dumper.dumps(target_schema.slots)
@@ -305,32 +301,28 @@ def test_copy_whitelisting(mapper):
         specification.class_derivations[derivation.name] = derivation
     target_schema = mapper.derive_schema(specification)
     # classes, slots and enums must have only what explicitly included
-    for schema_class in source_schema.classes.keys():
+    for schema_class in source_schema.classes:
         if schema_class in whitelist:
-            assert schema_class in target_schema.classes.keys(), (
+            assert schema_class in target_schema.classes, (
                 f"Class '{schema_class}' is missing in target"
             )
         else:
-            assert schema_class not in target_schema.classes.keys(), (
+            assert schema_class not in target_schema.classes, (
                 f"Class '{schema_class}' is missing in target"
             )
-    assert "Agent" in target_schema.classes.keys(), "Derived class 'Agent' is missing in target"
-    for schema_slot in source_schema.slots.keys():
+    assert "Agent" in target_schema.classes, "Derived class 'Agent' is missing in target"
+    for schema_slot in source_schema.slots:
         if schema_slot in whitelist:
-            assert schema_slot in target_schema.slots.keys(), (
-                f"Slot '{schema_slot}' is missing in target"
-            )
+            assert schema_slot in target_schema.slots, f"Slot '{schema_slot}' is missing in target"
         else:
-            assert schema_slot not in target_schema.slots.keys(), (
+            assert schema_slot not in target_schema.slots, (
                 f"Slot '{schema_slot}' is missing in target"
             )
-    for schema_enum in source_schema.enums.keys():
+    for schema_enum in source_schema.enums:
         if schema_enum in whitelist:
-            assert schema_enum in target_schema.enums.keys(), (
-                f"Enum '{schema_enum}' is missing in target"
-            )
+            assert schema_enum in target_schema.enums, f"Enum '{schema_enum}' is missing in target"
         else:
-            assert schema_enum not in target_schema.enums.keys(), (
+            assert schema_enum not in target_schema.enums, (
                 f"Enum '{schema_enum}' is missing in target"
             )
 

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -76,7 +76,7 @@ def test_transform_dict(obj_tr: ObjectTransformer) -> None:
     assert target_dict == TARGET_DATA
 
 
-def test_transform_dict_in_container(obj_tr: ObjectTransformer):
+def test_transform_dict_in_container(obj_tr: ObjectTransformer) -> None:
     """
     Tests transforming a Person data dict in a Container
     into an Agent data dict in a Container dict
@@ -97,7 +97,7 @@ def test_transform_multiple_dicts_in_container(obj_tr: ObjectTransformer) -> Non
     assert target_dict == CONTAINER_DATA
 
 
-def check_familial_relationships(obj, data_model, expected):
+def check_familial_relationships(obj, data_model, expected) -> None:
     assert len(expected) == len(obj.has_familial_relationships)
     for n in range(len(expected)):
         fr = obj.has_familial_relationships[n]
@@ -106,16 +106,18 @@ def check_familial_relationships(obj, data_model, expected):
         assert expected[n]["type"] == str(fr.type)
 
 
-def test_coerce(obj_tr: ObjectTransformer):
-    x = obj_tr._coerce_datatype("5", "integer")
-    assert x == 5
-    x = obj_tr._coerce_datatype(5, "string")
-    assert "5" == x
-    x = obj_tr._coerce_datatype(5, "integer")
-    assert 5 == x
+def test_coerce(obj_tr: ObjectTransformer) -> None:
+    five_int = 5
+    five_str = "5"
+    x = obj_tr._coerce_datatype(five_str, "integer")  # noqa: SLF001
+    assert x == five_int
+    x = obj_tr._coerce_datatype(five_int, "string")  # noqa: SLF001
+    assert x == five_str
+    x = obj_tr._coerce_datatype(five_int, "integer")  # noqa: SLF001
+    assert x == five_int
 
 
-def test_transform_simple_object(obj_tr: ObjectTransformer):
+def test_transform_simple_object(obj_tr: ObjectTransformer) -> None:
     """
     Tests transforming a Person object
     into an Agent object
@@ -146,7 +148,7 @@ def test_transform_simple_object(obj_tr: ObjectTransformer):
     target_obj = obj_tr.transform_object(person_obj, target_class=tgt_dm.Agent)
     assert isinstance(target_obj, tgt_dm.Agent)
     assert person_obj.name == target_obj.label
-    assert AGE_STRING == target_obj.age
+    assert target_obj.age == AGE_STRING
     assert target_obj.gender is None
 
     expected = [
@@ -167,7 +169,7 @@ def test_transform_simple_object(obj_tr: ObjectTransformer):
     assert target_obj == TARGET_OBJECT
 
 
-def test_transform_container_object(obj_tr: ObjectTransformer):
+def test_transform_container_object(obj_tr: ObjectTransformer) -> None:
     """
     Tests transforming a Container object holding a Person object
     into Container object holding an Agent object
@@ -187,7 +189,7 @@ def test_transform_container_object(obj_tr: ObjectTransformer):
         assert person_fr1.related_to == agent_fr1.related_to
 
 
-def test_transform_object_container(obj_tr: ObjectTransformer):
+def test_transform_object_container(obj_tr: ObjectTransformer) -> None:
     """
     Tests transforming a Container object holding several Person objects
     into Container object holding several Agent objects
@@ -201,7 +203,7 @@ def test_transform_object_container(obj_tr: ObjectTransformer):
 def check_subject_object_predicate(
     obj,
     expected,
-):
+) -> None:
     assert expected["subject_id"] == obj.subject.id
     assert expected["subject_name"] == obj.subject.name
     assert expected["object_id"] == obj.object.id
@@ -209,7 +211,7 @@ def check_subject_object_predicate(
     assert expected["predicate"] == obj.predicate
 
 
-def test_index_dict():
+def test_index_dict() -> None:
     sv = SchemaView(NORM_SCHEMA)
     container = yaml.safe_load(open(str(FLATTENING_DATA)))
     dynobj = dynamic_object(container, sv, "MappingSet")
@@ -233,13 +235,13 @@ def test_index_dict():
     tr.index(container, "MappingSet")
     dynobj = dynamic_object(container, sv, "MappingSet")
     mset = ix.bless(dynobj)
-    assert "U:1" == mset.mappings[0].subject
-    assert "Y:1" == mset.mappings[0].object.id
-    assert "y1" == mset.mappings[0].object.name
-    assert "P:1" == mset.mappings[0].predicate
+    assert mset.mappings[0].subject == "U:1"
+    assert mset.mappings[0].object.id == "Y:1"
+    assert mset.mappings[0].object.name == "y1"
+    assert mset.mappings[0].predicate == "P:1"
 
 
-def test_index_obj():
+def test_index_obj() -> None:
     sv = SchemaView(NORM_SCHEMA)
     mset: sssom_src_dm.MappingSet = yaml_loader.load(
         str(FLATTENING_DATA), target_class=sssom_src_dm.MappingSet
@@ -274,7 +276,7 @@ def test_index_obj():
     check_subject_object_predicate(mset.mappings[0], expected)
 
 
-def test_denormalized_transform_dict():
+def test_denormalized_transform_dict() -> None:
     """
     Tests denormalizing transformation.
 
@@ -302,7 +304,7 @@ def test_denormalized_transform_dict():
     }
 
 
-def test_denormalized_object_transform():
+def test_denormalized_object_transform() -> None:
     """
     Tests denormalizing transformation.
 
@@ -399,7 +401,7 @@ def test_cardinalities(source_multivalued: bool, target_multivalued: bool, expli
     assert [val] if target_multivalued else val == target_instance[att_name]
 
 
-def test_self_transform():
+def test_self_transform() -> None:
     tr = ObjectTransformer()
     tr.source_schemaview = SchemaView(str(TR_SCHEMA))
     tr.load_transformer_specification(TR_TO_MAPPING_TABLES)

--- a/tests/test_transformer/test_transformer_examples.py
+++ b/tests/test_transformer/test_transformer_examples.py
@@ -1,6 +1,7 @@
 """Tests ObjectTransformer using examples."""
 
 import pytest
+
 from linkml_map.utils.multi_file_transformer import MultiFileTransformer
 from tests import EXAMPLE_DIR
 
@@ -24,7 +25,7 @@ Assumes folder structures:
 """
 
 
-def test_all():
+def test_all() -> None:
     """
     Iterates through all examples.
 
@@ -39,7 +40,7 @@ def test_all():
 
 
 @pytest.mark.skip("Uncomment this to regenerate examples")
-def test_regenerate():
+def test_regenerate() -> None:
     """
     Use this to regenerate test examples.
     """


### PR DESCRIPTION
Awaiting the merge of #52.

Linter fixes in two categories:

Commit 1 is automatic "safe" fixes that Ruff performs, e.g.
- ordering imports
- switching to importing from more appropriate packages (e.g. `Iterator` from `abc.collections` instead of from `typing`)
- using `list`, `dict`, etc., for typing instead of `List`, `Dict`, etc.


Commit 2 is "safe" fixes that Ruff suggests via the IDE (but for some reason does not perform automatically - grrrr...)
- adding return typing to functions (a lot of `-> None`)
- adding typing to args
- a couple of naming fixes
- save error context so that rethrown errors will have a full stack trace
- create error messages as strings -- ruff complains if error messages are too long or contain interpolation
- a few code simplifications, such as using list comprehensions, ternaries, etc.

I'll add inline comments to anything interesting.