### PR TITLE
Automatic python code fixes suggested by ruff

### DIFF
--- a/src/linkml_map/compiler/compiler.py
+++ b/src/linkml_map/compiler/compiler.py
@@ -81,9 +81,9 @@ class Compiler(ABC):
     def _compile_iterator(self, specification: TransformationSpecification) -> Iterator[str]:
         raise NotImplementedError
 
-    def derived_target_schemaview(self, specification: TransformationSpecification):
+    def derived_target_schemaview(self, specification: TransformationSpecification) -> SchemaView:
         """
-        Returns a view over the target schema, including any derived classes.
+        Return a view over the target schema, including any derived classes.
         """
         mapper = SchemaMapper(source_schemaview=self.source_schemaview)
         return SchemaView(yaml_dumper.dumps(mapper.derive_schema(specification)))

--- a/src/linkml_map/compiler/graphviz_compiler.py
+++ b/src/linkml_map/compiler/graphviz_compiler.py
@@ -20,10 +20,10 @@ class Record(BaseModel):
     fields: list[tuple[str, str]] = []
 
     @property
-    def id(self):
+    def id(self) -> str:
         return f"{self.source}{self.name}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"""<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
@@ -47,6 +47,7 @@ class GraphvizObject(CompiledSpecification):
     def render(self, file_path: str, format="png", view=False) -> None:
         """
         Render a graphviz graph to a file.
+
         :param file_path:
         :return:
         """

--- a/src/linkml_map/compiler/j2_based_compiler.py
+++ b/src/linkml_map/compiler/j2_based_compiler.py
@@ -24,11 +24,13 @@ class J2BasedCompiler(Compiler):
         if not template_dir:
             template_dir = TEMPLATE_DIR
         if not template_dir:
-            raise ValueError("template_dir must be set")
+            msg = "template_dir must be set"
+            raise ValueError(msg)
         loader = FileSystemLoader(template_dir)
         env = Environment(loader=loader, autoescape=True)
         if not self.template_name:
-            raise ValueError("template_name must be set")
+            msg = "template_name must be set"
+            raise ValueError(msg)
         template = env.get_template(self.template_name)
         rendered = template.render(
             spec=specification,

--- a/src/linkml_map/compiler/python_compiler.py
+++ b/src/linkml_map/compiler/python_compiler.py
@@ -95,10 +95,7 @@ class PythonCompiler(Compiler):
 
     def _compiled_class_derivations_iter(self, cd: ClassDerivation) -> Iterator[str]:
         sv = self.source_schemaview
-        if cd.populated_from:
-            populated_from = cd.populated_from
-        else:
-            populated_from = cd.name
+        populated_from = cd.populated_from if cd.populated_from else cd.name
         if populated_from not in sv.all_classes():
             return
         induced_slots = {s.name: s for s in sv.class_induced_slots(populated_from)}

--- a/src/linkml_map/importer/importer.py
+++ b/src/linkml_map/importer/importer.py
@@ -27,7 +27,7 @@ class Importer(ABC):
     @abstractmethod
     def import_specification(self, input: Any) -> TransformationSpecification:
         """
-        Import into a specification
+        Import into a specification.
 
         :param specification:
         :return:

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -1,3 +1,5 @@
+"""Infer missing values in a specification."""
+
 from linkml_runtime import SchemaView
 
 from linkml_map.datamodel.transformer_model import TransformationSpecification
@@ -5,7 +7,7 @@ from linkml_map.datamodel.transformer_model import TransformationSpecification
 
 def induce_missing_values(
     specification: TransformationSpecification, source_schemaview: SchemaView
-):
+) -> None:
     """
     Infer missing values in a specification.
 
@@ -24,15 +26,14 @@ def induce_missing_values(
             # TODO: decide if this is the desired behavior
             if sd.populated_from is None and sd.expr is None:
                 sd.populated_from = sd.name
-            if not sd.range:
+            if not sd.range and sd.populated_from:
                 # auto-populate range field
-                if sd.populated_from:
-                    if cd.populated_from not in source_schemaview.all_classes():
-                        continue
-                    source_induced_slot = source_schemaview.induced_slot(
-                        sd.populated_from, cd.populated_from
-                    )
-                    source_induced_slot_range = source_induced_slot.range
-                    for range_cd in specification.class_derivations.values():
-                        if range_cd.populated_from == source_induced_slot_range:
-                            sd.range = range_cd.name
+                if cd.populated_from not in source_schemaview.all_classes():
+                    continue
+                source_induced_slot = source_schemaview.induced_slot(
+                    sd.populated_from, cd.populated_from
+                )
+                source_induced_slot_range = source_induced_slot.range
+                for range_cd in specification.class_derivations.values():
+                    if range_cd.populated_from == source_induced_slot_range:
+                        sd.range = range_cd.name

--- a/src/linkml_map/inference/schema_mapper.py
+++ b/src/linkml_map/inference/schema_mapper.py
@@ -291,9 +291,7 @@ class SchemaMapper:
         if slot_derivation.range:
             target_slot.range = slot_derivation.range
         if slot_derivation.target_definition:
-            spec_defn = SlotDefinition(
-                name=target_slot.name, **slot_derivation.target_definition
-            )
+            spec_defn = SlotDefinition(name=target_slot.name, **slot_derivation.target_definition)
             for k, v in vars(spec_defn).items():
                 setattr(target_slot, k, v)
         if slot_derivation.unit_conversion:
@@ -337,9 +335,7 @@ class SchemaMapper:
             new_parents = self.source_to_target_class_mappings[parent]
             if len(new_parents) > 1:
                 msg = f"Cannot rewire to non-isomorphic mappings {parent} => {new_parents}"
-                raise ValueError(
-                    msg
-                )
+                raise ValueError(msg)
             if len(new_parents) == 1:
                 return new_parents[0]
         parent_cls = self.source_schemaview.get_class(parent)

--- a/src/linkml_map/inference/schema_mapper.py
+++ b/src/linkml_map/inference/schema_mapper.py
@@ -56,21 +56,21 @@ class SchemaMapper:
         copy_directive: CopyDirective,
         src_elements,
         tgt_elements,
-    ):
+    ) -> None:
         if copy_directive.copy_all:
-            for element in src_elements.keys():
+            for element in src_elements:
                 tgt_elements[element] = src_elements[element]
         if copy_directive.exclude:
-            for element in src_elements.keys():
+            for element in src_elements:
                 if element in copy_directive.exclude:
                     del tgt_elements[element]
         if copy_directive.exclude_all:
-            elements_to_delete = [key for key in tgt_elements]
+            elements_to_delete = list(tgt_elements)
             for element in elements_to_delete:
                 del tgt_elements[element]
         if copy_directive.include:
             for element in copy_directive.include:
-                if element in src_elements.keys():
+                if element in src_elements:
                     tgt_elements[element] = src_elements[element]
 
     def _copy_list(
@@ -78,7 +78,7 @@ class SchemaMapper:
         copy_directive: CopyDirective,
         src_elements,
         tgt_elements,
-    ):
+    ) -> None:
         if copy_directive.copy_all:
             for element in src_elements:
                 tgt_elements.append(element)
@@ -224,7 +224,7 @@ class SchemaMapper:
             )
             for k, v in vars(spec_defn).items():
                 curr_v = getattr(target_class, k, None)
-                if curr_v is None or curr_v == [] or curr_v == {}:
+                if curr_v is None or curr_v in ([], {}):
                     setattr(target_class, k, v)
         self.source_to_target_class_mappings[populated_from].append(target_class.name)
         if class_derivation.overrides:
@@ -264,7 +264,8 @@ class SchemaMapper:
                     pv = PermissibleValue(text=source)
                     target_enum.permissible_values[pv.text] = pv
             else:
-                raise ValueError(f"Missing populated_from or sources for {pv_derivation}")
+                msg = f"Missing populated_from or sources for {pv_derivation}"
+                raise ValueError(msg)
         if enum_derivation.mirror_source:
             for pv in source_enum.permissible_values.values():
                 if pv.text not in target_enum.permissible_values:
@@ -323,7 +324,7 @@ class SchemaMapper:
             target_slot = SlotDefinition(**curr)
         return target_slot
 
-    def _rewire_class(self, class_definition: ClassDefinition):
+    def _rewire_class(self, class_definition: ClassDefinition) -> None:
         if class_definition.is_a:
             class_definition.is_a = self._rewire_parent(class_definition, class_definition.is_a)
         mixins = [self._rewire_parent(class_definition, m) for m in class_definition.mixins]
@@ -335,8 +336,9 @@ class SchemaMapper:
         if parent in self.source_to_target_class_mappings:
             new_parents = self.source_to_target_class_mappings[parent]
             if len(new_parents) > 1:
+                msg = f"Cannot rewire to non-isomorphic mappings {parent} => {new_parents}"
                 raise ValueError(
-                    f"Cannot rewire to non-isomorphic mappings {parent} => {new_parents}"
+                    msg
                 )
             if len(new_parents) == 1:
                 return new_parents[0]

--- a/src/linkml_map/session.py
+++ b/src/linkml_map/session.py
@@ -43,7 +43,7 @@ class Session:
 
     def set_transformer_specification(
         self, specification: Optional[Union[TransformationSpecification, dict, str, Path]] = None
-    ):
+    ) -> None:
         if isinstance(specification, Path):
             specification = str(specification)
         if isinstance(specification, TransformationSpecification):
@@ -63,9 +63,11 @@ class Session:
                 obj = yaml.safe_load(open(specification))
             self.set_transformer_specification(obj)
 
-    def set_source_schema(self, schema: Union[str, Path, dict, SchemaView, SchemaDefinition]):
+    def set_source_schema(
+        self, schema: Union[str, Path, dict, SchemaView, SchemaDefinition]
+    ) -> None:
         """
-        Sets the schema from a path or SchemaView object.
+        Set the schema from a path or SchemaView object.
         """
         if isinstance(schema, str):
             sv = SchemaView(schema)
@@ -78,7 +80,8 @@ class Session:
         elif isinstance(schema, SchemaDefinition):
             sv = SchemaView(schema)
         else:
-            raise ValueError(f"Unsupported schema type: {type(schema)}")
+            msg = f"Unsupported schema type: {type(schema)}"
+            raise ValueError(msg)
         self.source_schemaview = sv
         self._target_schema = None
 
@@ -86,7 +89,7 @@ class Session:
         self,
         transformer: Optional[Union[Transformer, type[Transformer]]],
         **kwargs,
-    ):
+    ) -> None:
         if isinstance(transformer, type):
             transformer = transformer()
         transformer.specification = self.transformer_specification
@@ -97,7 +100,7 @@ class Session:
         transformer: Optional[
             Union[ObjectTransformer, TransformationSpecification, dict, str, Path]
         ] = None,
-    ):
+    ) -> None:
         if transformer is None:
             if self.object_transformer is not None:
                 logger.info("No change")
@@ -130,7 +133,8 @@ class Session:
 
     def transform(self, obj: dict, **kwargs) -> dict:
         if self.object_transformer is None:
-            raise ValueError("No transformer specified")
+            msg = "No transformer specified"
+            raise ValueError(msg)
         if not self.object_transformer.source_schemaview:
             self.object_transformer.source_schemaview = self.source_schemaview
         return self.object_transformer.map_object(obj, **kwargs)

--- a/src/linkml_map/transformer/duckdb_transformer.py
+++ b/src/linkml_map/transformer/duckdb_transformer.py
@@ -1,3 +1,5 @@
+"""A Transformer that works on DuckDB data."""
+
 import logging
 from dataclasses import dataclass
 from typing import Any, Optional, Union
@@ -23,9 +25,9 @@ class DuckDBTransformer(Transformer):
     def map_object(
         self,
         source_obj: OBJECT_TYPE,
-        source_type: str = None,
-        target_type: str = None,
-        **kwargs,
+        source_type: Optional[str] = None,
+        target_type: Optional[str] = None,
+        **kwargs: Optional[dict[str, Any]],
     ) -> OBJECT_TYPE:
         """
         Transform a source object into a target object.
@@ -35,11 +37,14 @@ class DuckDBTransformer(Transformer):
         :param target_type: target_obj instantiates this (may be class, type, or enum)
         :return: transformed data, either as type target_type or a dictionary
         """
-        # sv = self.source_schemaview
-        raise NotImplementedError("DuckDBTransformer.transform")
+        msg = "DuckDBTransformer.transform"
+        raise NotImplementedError(msg)
 
     def map_database(
-        self, source_database: DATABASE, target_database: Optional[DATABASE] = None, **kwargs
+        self,
+        source_database: DATABASE,
+        target_database: Optional[DATABASE] = None,
+        **kwargs: Optional[dict[str, Any]],
     ) -> OBJECT_TYPE:
         """
         Transform source resource.
@@ -65,6 +70,7 @@ class DuckDBTransformer(Transformer):
         source_connection.sql(sql_compiler.create_ddl(self.source_schemaview))
         target_connection.sql(sql_compiler.create_ddl(self.target_schemaview))
         if not self.specification:
-            raise ValueError("No specification provided.")
+            msg = "No specification provided."
+            raise ValueError(msg)
         compiled = sql_compiler.compile(self.specification)
         source_connection.execute(compiled.serialization)

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -149,9 +149,8 @@ class Transformer(ABC):
         ]
         logger.debug(f"Target class derivations={matching_tgt_class_derivs}")
         if len(matching_tgt_class_derivs) != 1:
-            raise ValueError(
-                f"Could not find class derivation for {target_class_name} (results={len(matching_tgt_class_derivs)})"
-            )
+            msg = f"Could not find class derivation for {target_class_name} (results={len(matching_tgt_class_derivs)})"
+            raise ValueError(msg)
         cd = matching_tgt_class_derivs[0]
         ancmap = self._class_derivation_ancestors(cd)
         if ancmap:
@@ -193,7 +192,8 @@ class Transformer(ABC):
         ]
         logger.debug(f"Target enum derivations={matching_tgt_enum_derivs}")
         if len(matching_tgt_enum_derivs) != 1:
-            raise ValueError(f"Could not find what to derive from a source {target_enum_name}")
+            msg = f"Could not find what to derive from a source {target_enum_name}"
+            raise ValueError(msg)
         return matching_tgt_enum_derivs[0]
 
     def _is_coerce_to_multivalued(

--- a/src/linkml_map/utils/dynamic_object.py
+++ b/src/linkml_map/utils/dynamic_object.py
@@ -1,10 +1,12 @@
+"""Generate an object from a dict."""
+
 from typing import Any
 
 from linkml_runtime import SchemaView
 
 
 class DynObj:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -1,5 +1,5 @@
 """
-meta-circular interpreter for evaluating python expressions
+meta-circular interpreter for evaluating python expressions.
 
  - See `<https://stackoverflow.com/questions/2371436/evaluating-a-mathematical-expression-in-a-string>`_
 
@@ -27,16 +27,19 @@ compare_operators = {ast.Eq: op.eq, ast.Lt: op.lt, ast.LtE: op.le, ast.Gt: op.gt
 
 def eval_conditional(*conds: list[tuple[bool, Any]]) -> Any:
     """
+    Evaluate a conditional.
+
     >>> x = 10
     >>> eval_conditional((x < 25, 'low'), (x > 25, 'high'), (True, 'low'))
     'low'
 
-    :param subj:
-    :return:
+    :param conds: conditionals to be evaluated
+    :return: Any
     """
     for is_true, val in conds:
         if is_true:
             return val
+    return None
 
 
 funcs = {
@@ -55,7 +58,8 @@ class UnsetValueError(Exception):
 
 def eval_expr_with_mapping(expr: str, mapping: Mapping) -> Any:
     """
-    Evaluates a given expression, with restricted syntax.
+    Evaluate a given expression, with restricted syntax.
+
     This function is equivalent to eval_expr where **kwargs has been switched to a Mapping (eg. a dictionary).
     See eval_expr for details.
     """
@@ -70,7 +74,7 @@ def eval_expr_with_mapping(expr: str, mapping: Mapping) -> Any:
 
 def eval_expr(expr: str, **kwargs) -> Any:
     """
-    Evaluates a given expression, with restricted syntax
+    Evaluate a given expression, with restricted syntax.
 
     >>> eval_expr('2^6')
     4
@@ -161,13 +165,16 @@ def eval_(node, bindings=None):
     if isinstance(node, ast.Set):
         # sets are not part of the language; we use {x} as notation for x
         if len(node.elts) != 1:
-            raise ValueError("The {} must enclose a single variable")
+            msg = "The {} must enclose a single variable"
+            raise ValueError(msg)
         e = node.elts[0]
         if not isinstance(e, ast.Name):
-            raise ValueError("The {} must enclose a variable")
+            msg = "The {} must enclose a variable"
+            raise ValueError(msg)
         v = eval_(e, bindings)
         if v is None:
-            raise UnsetValueError(f"{e} is not set")
+            msg = f"{e} is not set"
+            raise UnsetValueError(msg)
         return v
     if isinstance(node, ast.Tuple):
         return tuple([eval_(x, bindings) for x in node.elts])
@@ -178,12 +185,15 @@ def eval_(node, bindings=None):
         }
     if isinstance(node, ast.Compare):  # <left> <operator> <right>
         if len(node.ops) != 1:
-            raise ValueError(f"Must be exactly one op in {node}")
+            msg = f"Must be exactly one op in {node}"
+            raise ValueError(msg)
         if type(node.ops[0]) not in compare_operators:
-            raise NotImplementedError(f"Not implemented: {node.ops[0]} in {node}")
+            msg = f"Not implemented: {node.ops[0]} in {node}"
+            raise NotImplementedError(msg)
         py_op = compare_operators[type(node.ops[0])]
         if len(node.comparators) != 1:
-            raise ValueError(f"Must be exactly one comparator in {node}")
+            msg = f"Must be exactly one comparator in {node}"
+            raise ValueError(msg)
         right = node.comparators[0]
         return py_op(eval_(node.left, bindings), eval_(right, bindings))
     if isinstance(node, ast.BinOp):  # <left> <operator> <right>
@@ -207,5 +217,6 @@ def eval_(node, bindings=None):
                 if isinstance(args[0], list) and not takes_list:
                     return [func(*[x] + args[1:]) for x in args[0]]
                 return func(*args)
-        raise NotImplementedError(f"Call {node.func} not implemented. node = {node}")
+        msg = f"Call {node.func} not implemented. node = {node}"
+        raise NotImplementedError(msg)
     raise TypeError(node)

--- a/src/linkml_map/utils/multi_file_transformer.py
+++ b/src/linkml_map/utils/multi_file_transformer.py
@@ -83,23 +83,27 @@ class MultiFileTransformer:
         if isinstance(root_directory, str):
             root_directory = Path(root_directory)
         if not root_directory.exists():
-            raise ValueError(f"No such directory {root_directory}")
+            msg = f"No such directory {root_directory}"
+            raise ValueError(msg)
         instructions_file = root_directory / "instructions.yaml"
         if instructions_file.exists():
             with open(instructions_file) as file:
                 return Instructions(**yaml.safe_load(file))
         source_schema_directory = root_directory / self.source_schema_directory_base
         if not source_schema_directory.exists():
-            raise ValueError(f"Expected {source_schema_directory}")
+            msg = f"Expected {source_schema_directory}"
+            raise ValueError(msg)
         transform_specification_directory = (
             root_directory / self.transform_specification_directory_base
         )
         if not transform_specification_directory.exists():
-            raise ValueError(f"Expected {transform_specification_directory}")
+            msg = f"Expected {transform_specification_directory}"
+            raise ValueError(msg)
         target_schema_directory = root_directory / self.target_schema_directory_base
         input_schemas = glob.glob(os.path.join(str(source_schema_directory), "*.yaml"))
         if not input_schemas:
-            raise ValueError(f"Expected schemas in {source_schema_directory}")
+            msg = f"Expected schemas in {source_schema_directory}"
+            raise ValueError(msg)
         transform_files = glob.glob(
             os.path.join(str(transform_specification_directory), "*.transform.yaml")
         )
@@ -116,7 +120,8 @@ class MultiFileTransformer:
                     # resolve which schema the transform applies to
                     matches = re.match(r"^(\w+)-to-(\w+)\.", transform_file)
                     if not matches:
-                        raise ValueError(f"Ambiguous: {transform_file}")
+                        msg = f"Ambiguous: {transform_file}"
+                        raise ValueError(msg)
                     src, target_schema_base = matches.group(1, 2)
                     if src not in input_schema:
                         continue
@@ -136,17 +141,18 @@ class MultiFileTransformer:
                 if len(target_schemas) > 1:
                     target_schemas = [s for s in target_schemas if target_schema_base in s]
                     if len(target_schemas) != 1:
-                        raise ValueError(
-                            f"Could not determine target schema from: {target_schemas}"
-                        )
+                        msg = f"Could not determine target schema from: {target_schemas}"
+                        raise ValueError(msg)
                 if target_schemas:
                     tr.target_schema = target_schemas[0]
                 else:
                     tr.target_schema = str(Path(target_schema_directory) / "target.yaml")
                 if not tr.steps:
-                    raise ValueError(f"Could not infer steps from {data_files}")
+                    msg = f"Could not infer steps from {data_files}"
+                    raise ValueError(msg)
                 if not tr.transformation_specification:
-                    raise ValueError(f"No spec {tr}")
+                    msg = f"No spec {tr}"
+                    raise ValueError(msg)
         return instructions
 
     def process_instructions(
@@ -155,7 +161,7 @@ class MultiFileTransformer:
         root_directory: Optional[Union[str, Path]],
         output_directory=None,
         test_mode=False,
-    ):
+    ) -> None:
         """
         Process a set of instructions to transform one or more files.
 
@@ -201,9 +207,8 @@ class MultiFileTransformer:
                             compare_obj = yaml.safe_load(f)
                             if compare_obj != target_obj:
                                 if test_mode and not overwrite:
-                                    raise ValueError(
-                                        f"Output different than expected: {compare_obj}"
-                                    )
+                                    msg = f"Output different than expected: {compare_obj}"
+                                    raise ValueError(msg)
                                 logging.warning(f"Different: {compare_obj}")
                     with open(str(out_path), "w", encoding="utf-8") as f:
                         yaml_str = yaml.dump(target_obj, sort_keys=False)


### PR DESCRIPTION
A variety of automated fixes from ruff. These include:
- add in typing
- `if` / `else` merging
- assign error messages to a variable and then call `Error(msg)` instead of using `Error(f"potentially very long message with a load of {string} {interpolation} that ruff dislikes...")`
- if an error is raised after catching an exception, use `raise Error(msg) from caught_error` so that the call stack gets correctly reported
- replace all uses of `for x in dict.keys()` with `for x in dict`