### PR TITLE
update make install command to bring in the dev group and not update the lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ status: check-config
 setup: install gen-project gendoc git-init-add
 
 install:
-	uv sync
+	uv sync --frozen --all-groups
 .PHONY: install
 
 all: gen-project gendoc


### PR DESCRIPTION
Small tweak on the uv command so that it installs necessary dev packages by default and doesn't update the lock file unintentionally (matching poetry install behavior). 