### PR TITLE
Implement transform on in-lined classes in multi-value slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ site/
 __pycache__
 tests/output/
 dist/*
+.vscode
+mise.toml
+

--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -566,6 +566,8 @@ class ClassDerivation(ElementDerivation):
         },
     )
 
+class ObjectDerivation(BaseModel):
+    class_derivations: Dict[str, ClassDerivation]
 
 class AliasedClass(ConfiguredBaseModel):
     """
@@ -641,6 +643,7 @@ class SlotDerivation(ElementDerivation):
             }
         },
     )
+    object_derivations: Optional[List[ObjectDerivation]] = None
     derived_from: Optional[List[str]] = Field(
         default_factory=list,
         description="""Source slots that are used to derive this slot. This can be computed from the expr, if the expr is declarative.""",

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -212,6 +212,13 @@ classes:
       sources:
         range: SlotReference
         multivalued: true
+      object_derivations:
+        description: >-
+          One or more object derivations used to construct the slot value(s), 
+          which must be instances of a class.
+        range: ObjectDerivation
+        multivalued: true
+        inlined: true
       derived_from:
         range: SlotReference
         multivalued: true

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -22,6 +22,10 @@ def induce_missing_values(
             cd.populated_from = cd.name
     for cd in specification.class_derivations.values():
         for sd in cd.slot_derivations.values():
+            if sd.object_derivations:
+                #skip inference for object derivations, inferencese come from class derivation later
+                #TODO: we may need to do the inference for the internal class slots
+                continue
             # for null mappings, assume that the slot is copied from the same slot in the source
             # TODO: decide if this is the desired behavior
             if sd.populated_from is None and sd.expr is None:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -229,6 +229,9 @@ class ObjectTransformer(Transformer):
                     v = aeval.symtable["target"]
             elif slot_derivation.populated_from:
                 v = source_obj.get(slot_derivation.populated_from, None)
+                if slot_derivation.value_mappings and v is not None:
+                    mapped = slot_derivation.value_mappings.get(str(v), None)
+                    v = mapped.value if mapped is not None else None
                 source_class_slot = sv.induced_slot(slot_derivation.populated_from, source_type)
                 logger.debug(
                     f"Pop slot {slot_derivation.name} => {v} using {slot_derivation.populated_from} // {source_obj}"

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -58,7 +58,6 @@ def inject_slot(schema_dict: dict, class_name: str, slot_name: str, slot_def: di
     schema_dict["classes"][class_name].setdefault("slots", []).append(slot_name)
 
 def inject_enum(schema: dict, enum_name: str, values: list[str]) -> None:
-    schema.setdefault("enums", {})
     schema["enums"][enum_name] = { "permissible_values": {val: {} for val in values} }
 
 @pytest.fixture
@@ -123,7 +122,7 @@ def test_coerce(obj_tr: ObjectTransformer) -> None:
 
 def test_value_mappings() -> None:
     """
-    Tests transforming a dictionary of Person data into a dictionary of Agent data.
+    Tests transforming using value mappings.
     """
     source_schema: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_SRC_SCHEMA)))
     work_int_dict = { "range": "integer", "minimum_value": 1, "maximum_value": 2}
@@ -135,8 +134,10 @@ def test_value_mappings() -> None:
     inject_slot(target_schema, "Agent", "work_value", work_enum_dict)
 
     transform_spec: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_TR)))
-    transform_spec_dict = \
-        { "populated_from": "work_type", "value_mappings": { "1": "Home", "2": "Office" } }
+    transform_spec_dict = {
+        "populated_from": "work_type",
+        "value_mappings": { "1": "Home", "2": "Office" }
+    }
     transform_spec.setdefault("class_derivations", {}).setdefault("Agent", {}) \
               .setdefault("slot_derivations", {})["work_value"] = transform_spec_dict
 

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -154,12 +154,6 @@ def test_value_mappings() -> None:
     TARGET_DATA["work_value"] = "Home"
     assert target_dict == TARGET_DATA
 
-# def test_transform_slots_to_nested_list_of_dicts(obj_tr: ObjectTransformer) -> None:
-#     """
-#     Tests transforming a Person object with slots that should be transformed into a nested list of dicts.
-#     """
-#     source_schema: dict[str, Any] = yaml.safe_load(open(str(PERSONINFO_SRC_SCHEMA)))
-
 def test_object_derivations() -> None:
     """
     Test nested object_derivations inside slot_derivations using YAML transform spec.
@@ -201,31 +195,23 @@ def test_object_derivations() -> None:
             object_derivations:
               - class_derivations:
                   Condition:
-                    name: Condition
                     populated_from: Person
                     slot_derivations:
                       condition_concept:
-                        name: condition_concept
                         expr: "'HP:0001681'"
                       condition_status:
-                        name: condition_status
                         populated_from: phv00159563
                       condition_providence:
-                        name: condition_providence
                         populated_from: phv00159569
               - class_derivations:
                   Condition:
-                    name: Condition
                     populated_from: Person
                     slot_derivations:
                       condition_concept:
-                        name: condition_concept
                         expr: "'HP:0001683'"
                       condition_status:
-                        name: condition_status
                         populated_from: phv00159573
                       condition_providence:
-                        name: condition_providence
                         populated_from: phv00159579
     """
 

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -121,6 +121,8 @@ def test_coerce(obj_tr: ObjectTransformer) -> None:
     x = obj_tr._coerce_datatype(5, "integer")  # noqa: SLF001
     assert x == 5
 
+# I expect this to fail because it is not implemented yet
+@pytest.mark.xfail(reason="value_mappings not implemented yet")
 def test_value_mappings() -> None:
     """
     Tests transforming a dictionary of Person data into a dictionary of Agent data.

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -121,8 +121,6 @@ def test_coerce(obj_tr: ObjectTransformer) -> None:
     x = obj_tr._coerce_datatype(5, "integer")  # noqa: SLF001
     assert x == 5
 
-# I expect this to fail because it is not implemented yet
-@pytest.mark.xfail(reason="value_mappings not implemented yet")
 def test_value_mappings() -> None:
     """
     Tests transforming a dictionary of Person data into a dictionary of Agent data.


### PR DESCRIPTION
This implements the object_derivations spec which allows a slot to have multiple in-line classes as a list for the value of the slot. I'm open to suggestions and changes. I'm even open to the idea that this is the wrong approach entirely but I need this sort of functionality for a transform that I'm currently doing on a short time-frame. I'll be running this code from this PR branch.