### PR TITLE
Address `Page not found`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install:
 
 all: gen-project gendoc
 %.yaml: gen-project
-deploy: all mkd-gh-deploy
+deploy: all deploy-gh-doc
 
 # TODO: make this default
 src/linkml_map/datamodel/transformer_model.py: src/linkml_map/datamodel/transformer_model.yaml

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Not all parts of the model are implemented in the reference Python framework.
 
 ## Quickstart
 
-* [Tutorial Notebook](src/docs/examples/Tutorial.ipynb)
+* [Tutorial Notebook](docs/examples/Tutorial.ipynb)
 * [Generated Docs](https://linkml.github.io/linkml-map/)
 * [Compliance Suite](https://linkml.github.io/linkml-map/specification/compliance)
-* [API Docs](https://linkml.github.io/linkml-map/api)
-
+* [API Docs](https://linkml.github.io/linkml-map/#api/session)

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Not all parts of the model are implemented in the reference Python framework.
 * [Tutorial Notebook](docs/examples/Tutorial.ipynb)
 * [Generated Docs](https://linkml.github.io/linkml-map/)
 * [Compliance Suite](https://linkml.github.io/linkml-map/specification/compliance)
-* [API Docs](https://linkml.github.io/linkml-map/#api/session)
+* [API Docs](https://linkml.github.io/linkml-map/api/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,10 +35,10 @@ nav:
       - Session: api/session.md
       - Transformer: api/transformer.md
       - Compiler: api/compiler.md
-      - Importer: api/importer.md
+      # - Importer: api/importer.md
       - Inference: api/inference.md
       - Functions: api/functions.md
-      - Subsetter: api/subsetter.md
+      # - Subsetter: api/subsetter.md
   - FAQ: faq.md
 site_url: https://linkml.github.io/linkml-map/
 repo_url: https://github.com/linkml/linkml-map/


### PR DESCRIPTION
There are a couple of URLs I found led to nowhere. Tried to fix the ones I could. 
  - Updated the `MakeFile` since the target replaced was not there and the live documentation does not match the docs locally generated via `make serve`
  - README urls should work once documentation is deployed properly
  - commented out some links in `mkdocs.yaml` since markdown files are absent.
    ```
          # - Importer: api/importer.md
          # - Subsetter: api/subsetter.md
    ```