### PR TITLE
Map value when single value provided for multivalued slot.

### DIFF
--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -266,7 +266,7 @@ class ObjectTransformer(Transformer):
                             for k1, v1 in v.items()
                         }
                     else:
-                        v = [v]
+                        v = [self.map_object(v, source_class_slot_range, target_range)]
                 else:
                     v = self.map_object(v, source_class_slot_range, target_range)
                 if (

--- a/tests/input/examples/single_value_for_multivalued/data/Container-001.yaml
+++ b/tests/input/examples/single_value_for_multivalued/data/Container-001.yaml
@@ -1,0 +1,8 @@
+my_greetings:
+  - greeting:
+    - konnichiwa
+    - hello
+    - bonjour
+  - greeting:
+    - ciao
+  - greeting: namaste

--- a/tests/input/examples/single_value_for_multivalued/output/Container-001.transformed.yaml
+++ b/tests/input/examples/single_value_for_multivalued/output/Container-001.transformed.yaml
@@ -1,0 +1,9 @@
+my_languages:
+- language:
+  - Japanese
+  - English
+  - French
+- language:
+  - Italian
+- language:
+  - Hindi

--- a/tests/input/examples/single_value_for_multivalued/source/greetings.yaml
+++ b/tests/input/examples/single_value_for_multivalued/source/greetings.yaml
@@ -1,0 +1,31 @@
+name: greetings
+id: greetings
+description: Greetings from different languages
+imports:
+- linkml:types
+default_range: string
+enums:
+  greetings:
+    permissible_values:
+      bonjour:
+      ciao:
+      hello:
+      hola:
+      konnichiwa:
+      namaste:
+classes:
+  my_greetings:
+    slots:
+      - greeting
+  Container:
+    tree_root: True
+    attributes:
+      my_greetings:
+        range: my_greetings
+        multivalued: True
+        inlined_as_list: True
+slots:
+    greeting:
+      range: greetings
+      multivalued: True
+      inlined_as_list: True

--- a/tests/input/examples/single_value_for_multivalued/target/languages.yaml
+++ b/tests/input/examples/single_value_for_multivalued/target/languages.yaml
@@ -1,0 +1,31 @@
+name: languages
+id: languages
+description: Names of languages
+imports:
+- linkml:types
+default_range: string
+enums:
+  languages:
+    permissible_values:
+      English:
+      French:
+      Hindi:
+      Italian:
+      Japanese:
+      Spanish:
+classes:
+  my_languages:
+    slots:
+      - language
+  Container:
+    tree_root: True
+    attributes:
+      my_languages:
+        range: my_languages
+        multivalued: True
+        inlined_as_list: True
+slots:
+    language:
+      range: languages
+      multivalued: True
+      inlined_as_list: True

--- a/tests/input/examples/single_value_for_multivalued/transform/greetings-to-languages.transform.yaml
+++ b/tests/input/examples/single_value_for_multivalued/transform/greetings-to-languages.transform.yaml
@@ -1,0 +1,38 @@
+class_derivations:
+  my_languages:
+    name: my_languages
+    populated_from: my_greetings
+    slot_derivations:
+      language:
+        name: language
+        populated_from: greeting
+  Container:
+    name: Container
+    slot_derivations:
+      my_languages:
+        populated_from: my_greetings
+enum_derivations:
+  languages:
+    name: languages
+    mirror_source: false
+    populated_from: greetings
+    permissible_value_derivations:
+      English:
+        name: English
+        populated_from: hello
+      French:
+        name: French
+        populated_from: bonjour
+      Hindi:
+        name: Hindi
+        populated_from: namaste
+      Italian:
+        name: Italian
+        populated_from: ciao
+      Japanese:
+        name: Japanese
+        populated_from: konnichiwa
+      Spanish:
+        name: Spanish
+        populated_from: hola
+        

--- a/tests/test_transformer/test_transformer_examples.py
+++ b/tests/test_transformer/test_transformer_examples.py
@@ -8,6 +8,7 @@ from tests import EXAMPLE_DIR
 EXAMPLE_PROJECTS = [
     "measurements",
     "personinfo_basic",
+    "single_value_for_multivalued",
 ]
 
 


### PR DESCRIPTION
In ObjectTransformer's map_object function, if a single-valued value is provided but the source slot is multi-valued, then previously the value was converted to a list without mapping the value:

```python
v = [v]
```

The desired behaviour is to both convert the single value to a list and also map that single value:

```python
v = [self.map_object(v, source_class_slot_range, target_range)]
```

Closes #59 