### PR TITLE
Slot derivation for constant values

### DIFF
--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -661,6 +661,16 @@ class SlotDerivation(ElementDerivation):
             }
         },
     )
+    value: Optional[Any] = Field(
+        None,
+        description="""A constant value to assign to this slot, overriding all other derivations""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "value",
+                "domain_of": ["SlotDerivation"]
+            }
+        },
+    )
     range: Optional[str] = Field(
         None,
         json_schema_extra={

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -206,7 +206,9 @@ class ObjectTransformer(Transformer):
         for slot_derivation in class_deriv.slot_derivations.values():
             v = None
             source_class_slot = None
-            if slot_derivation.unit_conversion:
+            if slot_derivation.value is not None:
+                v = slot_derivation.value
+            elif slot_derivation.unit_conversion:
                 v = self._perform_unit_conversion(slot_derivation, source_obj, sv, source_type)
             elif slot_derivation.expr:
                 if bindings is None:


### PR DESCRIPTION
We occasionally need to embed data in a transform from metadata which results in needing to add this as a constant for certain fields. This enables a `value:` slot_derivation that allows us to add these constants more simply rather than relying on an `expr:` slot_derivation. An important part here is that it is more declarative than an `expr:` where it can be more difficult to understand what is being done.