### PR TITLE
Route enum expr evaluation through the gated eval path

### DIFF
--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -30,7 +30,7 @@ from linkml_map.functions.unit_conversion import UnitSystem, convert_units
 from linkml_map.transformer.errors import TransformationError
 from linkml_map.transformer.transformer import OBJECT_TYPE, Transformer
 from linkml_map.utils.dynamic_object import DynObj, dynamic_object
-from linkml_map.utils.eval_utils import _uuid5, eval_expr, eval_expr_with_mapping
+from linkml_map.utils.eval_utils import _uuid5, eval_expr_with_mapping
 from linkml_map.utils.fk_utils import FKResolution, resolve_fk_path
 from linkml_map.utils.join_utils import join_keys
 
@@ -592,12 +592,30 @@ class ObjectTransformer(Transformer):
             if not self.unrestricted_eval:
                 raise
             ctxt_obj, _ = bindings.get_ctxt_obj_and_dict()
-            usersyms = {"src": ctxt_obj, "target": None, "uuid5": _uuid5}
-            if functions:
-                usersyms.update(functions)
-            aeval = Interpreter(usersyms=usersyms)
-            aeval(expr)
-            return aeval.symtable["target"]
+            return self._unrestricted_eval(expr, ctxt_obj, functions=functions)
+
+    def _unrestricted_eval(
+        self,
+        expr: str,
+        src: Any,
+        functions: dict[str, Any] | None = None,
+    ) -> Any:
+        """Evaluate *expr* with the unrestricted asteval interpreter.
+
+        This is the escape hatch reached only when restricted evaluation fails
+        *and* the user opted in via ``unrestricted_eval``. Callers own the gate;
+        this method assumes the opt-in has already been checked.
+
+        :param expr: The expression string to evaluate.
+        :param src: Object exposed to the expression as ``src``.
+        :param functions: Extra functions injected into the interpreter.
+        """
+        usersyms = {"src": src, "target": None, "uuid5": _uuid5}
+        if functions:
+            usersyms.update(functions)
+        aeval = Interpreter(usersyms=usersyms)
+        aeval(expr)
+        return aeval.symtable["target"]
 
     def _apply_mappings(
         self,
@@ -1288,12 +1306,18 @@ class ObjectTransformer(Transformer):
         for enum_name in enum_names:
             enum_deriv = self._get_enum_derivation(enum_name)
             if enum_deriv.expr:
+                mapping = {**source_obj, "NULL": None} if isinstance(source_obj, Mapping) else {"NULL": None}
                 try:
-                    v = eval_expr(enum_deriv.expr, **source_obj, NULL=None)
-                except Exception:
-                    aeval = Interpreter(usersyms={"src": source_obj, "target": None, "uuid5": _uuid5})
-                    aeval(enum_deriv.expr)
-                    v = aeval.symtable["target"]
+                    v = eval_expr_with_mapping(
+                        enum_deriv.expr,
+                        mapping,
+                        strict=self.strict,
+                        warned_unbound=self._warned_unbound_names,
+                    )
+                except (InvalidExpression, TypeError, ValueError):
+                    if not self.unrestricted_eval:
+                        raise
+                    v = self._unrestricted_eval(enum_deriv.expr, source_obj)
                 if v is not None:
                     return v
             for pv_deriv in enum_deriv.permissible_value_derivations.values():

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -1306,7 +1306,11 @@ class ObjectTransformer(Transformer):
         for enum_name in enum_names:
             enum_deriv = self._get_enum_derivation(enum_name)
             if enum_deriv.expr:
-                mapping = {**source_obj, "NULL": None} if isinstance(source_obj, Mapping) else {"NULL": None}
+                mapping = (
+                    {**source_obj, "NULL": None}
+                    if isinstance(source_obj, Mapping)
+                    else {"src": source_obj, "NULL": None}
+                )
                 try:
                     v = eval_expr_with_mapping(
                         enum_deriv.expr,

--- a/tests/test_transformer/test_multi_enum.py
+++ b/tests/test_transformer/test_multi_enum.py
@@ -359,7 +359,7 @@ def test_enum_expr_restricted_evaluates():
 
 
 def test_enum_expr_unrestricted_fallback():
-    """An expr simpleeval rejects falls back to asteval only when unrestricted_eval is opted in."""
+    """An expression rejected by simpleeval falls back to asteval only when unrestricted_eval is opted in."""
     tr = _make_transformer_with_enum_expr("target = src['color']", unrestricted_eval=True)
     result = tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
     assert result["color"] == "light_red"
@@ -368,6 +368,19 @@ def test_enum_expr_unrestricted_fallback():
 def test_enum_expr_restricted_raises_without_opt_in():
     """The same asteval-only expr raises rather than silently escalating when not opted in."""
     tr = _make_transformer_with_enum_expr("target = src['color']", unrestricted_eval=False)
+    with pytest.raises(TransformationError):
+        tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
+
+
+@pytest.mark.parametrize("unrestricted_eval", [False, True])
+def test_enum_expr_strict_unknown_name_raises_without_fallback(unrestricted_eval):
+    """A strict-mode typo in an enum expr raises and never escalates to unrestricted eval."""
+    tr = ObjectTransformer(strict=True, unrestricted_eval=unrestricted_eval)
+    tr.source_schemaview = SchemaView(SOURCE_SCHEMA)
+    tr.target_schemaview = SchemaView(TARGET_SCHEMA)
+    spec = copy.deepcopy(TRANSFORM_SPEC)
+    spec["enum_derivations"]["SimplePrimary"]["expr"] = "colorr"
+    tr.create_transformer_specification(spec)
     with pytest.raises(TransformationError):
         tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
 

--- a/tests/test_transformer/test_multi_enum.py
+++ b/tests/test_transformer/test_multi_enum.py
@@ -13,6 +13,7 @@ import copy
 import pytest
 from linkml_runtime import SchemaView
 
+from linkml_map.transformer.errors import TransformationError
 from linkml_map.transformer.object_transformer import ObjectTransformer
 
 SOURCE_SCHEMA = """\
@@ -337,6 +338,38 @@ def test_pv_sources_only_is_migrated_to_populated_from():
     assert pvds["red"].populated_from == ["light_red", "dark_red"]
     # sources is cleared after migration — the runtime relies on populated_from alone.
     assert not pvds["red"].sources
+
+
+def _make_transformer_with_enum_expr(expr: str, unrestricted_eval: bool) -> ObjectTransformer:
+    """Build a transformer whose SimplePrimary enum derivation carries *expr*."""
+    tr = ObjectTransformer(unrestricted_eval=unrestricted_eval)
+    tr.source_schemaview = SchemaView(SOURCE_SCHEMA)
+    tr.target_schemaview = SchemaView(TARGET_SCHEMA)
+    spec = copy.deepcopy(TRANSFORM_SPEC)
+    spec["enum_derivations"]["SimplePrimary"]["expr"] = expr
+    tr.create_transformer_specification(spec)
+    return tr
+
+
+def test_enum_expr_restricted_evaluates():
+    """A restricted-syntax enum expr is evaluated against the source object, no opt-in needed."""
+    tr = _make_transformer_with_enum_expr("'EXPR:' + color", unrestricted_eval=False)
+    result = tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
+    assert result["color"] == "EXPR:light_red"
+
+
+def test_enum_expr_unrestricted_fallback():
+    """An expr simpleeval rejects falls back to asteval only when unrestricted_eval is opted in."""
+    tr = _make_transformer_with_enum_expr("target = src['color']", unrestricted_eval=True)
+    result = tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
+    assert result["color"] == "light_red"
+
+
+def test_enum_expr_restricted_raises_without_opt_in():
+    """The same asteval-only expr raises rather than silently escalating when not opted in."""
+    tr = _make_transformer_with_enum_expr("target = src['color']", unrestricted_eval=False)
+    with pytest.raises(TransformationError):
+        tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
 
 
 def test_explicit_range_any_with_any_of():

--- a/tests/test_transformer/test_multi_enum.py
+++ b/tests/test_transformer/test_multi_enum.py
@@ -385,6 +385,53 @@ def test_enum_expr_strict_unknown_name_raises_without_fallback(unrestricted_eval
         tr.map_object({"id": "light1", "color": "light_red"}, source_type="Light")
 
 
+def test_scalar_enum_expr_can_reference_source_as_src_in_restricted_mode():
+    """A plain enum-range slot passes the scalar value; the expr sees it as ``src`` without opt-in."""
+    source_schema = """\
+id: https://example.org/scalar-source
+name: scalar-source
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+enums:
+  Color:
+    permissible_values:
+      red:
+      green:
+classes:
+  Rec:
+    tree_root: true
+    attributes:
+      id:
+        identifier: true
+        range: string
+      color:
+        range: Color
+"""
+    target_schema = source_schema.replace("scalar-source", "scalar-target").replace("Color", "TColor")
+
+    tr = ObjectTransformer(unrestricted_eval=False)
+    tr.source_schemaview = SchemaView(source_schema)
+    tr.target_schemaview = SchemaView(target_schema)
+    tr.create_transformer_specification(
+        {
+            "class_derivations": {
+                "Rec": {
+                    "populated_from": "Rec",
+                    "slot_derivations": {"id": {}, "color": {"populated_from": "color"}},
+                }
+            },
+            "enum_derivations": {
+                "TColor": {"name": "TColor", "populated_from": "Color", "expr": "'X:' + src"},
+            },
+        }
+    )
+
+    result = tr.map_object({"id": "r1", "color": "red"}, source_type="Rec")
+    assert result["color"] == "X:red"
+
+
 def test_explicit_range_any_with_any_of():
     """Slots with explicit range: Any plus any_of enum ranges are mapped correctly."""
     schema = SOURCE_SCHEMA.replace(


### PR DESCRIPTION
Enum `expr` evaluation silently escalated to the unrestricted asteval interpreter regardless of `--unrestricted-eval`. `transform_enum` caught a bare `except Exception` and dropped straight into a full asteval `Interpreter`, so any enum expression that failed restricted evaluation — including a plain typo — got full interpreter access with no opt-in. The bare catch also swallowed the strict-mode `NameError` that `eval_utils.py` raises specifically so it propagates.

This routes enum `expr` through the same restricted-then-gated-fallback path already used for slot exprs: restricted eval first, and asteval fallback only when `unrestricted_eval` is set — otherwise it re-raises. The shared asteval fallback is extracted into `_unrestricted_eval` so there is one gated eval path.

Tests cover all three cases: a restricted enum expr still evaluates with no opt-in, an asteval-only expr works under `unrestricted_eval=True`, and the same expr raises without the opt-in (the escalation the old code silently allowed).

Closes #294