### PR TITLE
Hold ucumvert at 0.2.x while Python 3.10 is still supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # ucumvert 0.3 requires pint>=0.25, which is Python 3.11+. Lift this once
+      # 3.10 reaches EOL (2026-10-31) and requires-python moves off it.
+      - dependency-name: "ucumvert"
+        versions: [">=0.3"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The weekly Dependabot `uv` job has been failing since #311 merged. It can't resolve an upgrade to `ucumvert` 0.3.0, which depends on `pint>=0.25` — and pint dropped Python 3.10 at 0.25:

```
Because the requested Python version (>=3.10) does not satisfy Python>=3.11
and pint>=0.25 depends on Python>=3.11, we can conclude that pint>=0.25
cannot be used.
```

Nothing is broken at runtime — current installs resolve fine on 3.10. It's only the *upgrade* that's unsatisfiable, so the cost is a red run in the Actions tab each week.

uv's hint is to raise `requires-python` to `>=3.11`, but that's premature: `linkml` and `linkml-runtime` both still declare `>=3.10` on PyPI (1.11.1) and on their main branch, and 3.10 isn't EOL until 2026-10-31. Raising our floor now would drop consumers the core libraries still support, to unblock one transitive bump.

So this scopes an ignore to `ucumvert >= 0.3` — every other ucumvert release still flows through. The `python-version-cycle` workflow added in #311 will open an issue on the November 1st run when 3.10 goes EOL; that's the point to drop 3.10, raise the floor, and delete this ignore.