### PR TITLE
Lint with the ruff from uv.lock instead of a separate pre-commit pin

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          prune-cache: true
+
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           prune-cache: true
 
+      - name: Install dependencies
+        run: uv sync
+
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,19 @@ repos:
       - id: trailing-whitespace
         exclude: ^(tests/input/|src/linkml_map/datamodel/|docs/schema/)
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+  # Run the ruff from uv.lock rather than a separately pinned copy, so local
+  # hooks, `uv run ruff`, and CI can't drift apart.
+  - repo: local
     hooks:
       - id: ruff-check
-        args: [--fix, --exit-non-zero-on-fix]
+        name: ruff check
+        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
       - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true


### PR DESCRIPTION
`.pre-commit-config.yaml` pinned `ruff-pre-commit` at `v0.11.13` while `uv.lock` had moved on to 0.15.22 — and #313 takes it to 0.16.1. Since `quality-checks` runs pre-commit, CI has been enforcing a ruff that nobody runs locally, five minor versions behind the one `uv run ruff` uses.

Nothing keeps those in step. Dependabot has no pre-commit ecosystem, so it bumps the lock and never touches the rev; the two were clearly in sync once (`ruff>=0.11` against `v0.11.13`) and drifted apart silently.

So the ruff hooks now shell out to `uv run ruff`, which makes the lock the single source of truth, and `quality-checks` gets a uv to run them with. `types_or` keeps `jupyter` so coverage matches what the stock hook did.

The trade-off is losing pre-commit's isolation for these two hooks — they now need the project env, so a cold clone pays a `uv sync` on first run. That seems fair in a uv-native repo where contributors sync anyway.

Behaviour-neutral today: `ruff@0.16.1 check .` passes and `format --check` reports every file already formatted, so this doesn't drag a reformat along with it. `pre-commit run --all-files` passes locally against the locked 0.15.22.