### PR TITLE
Retire the cookiecutter scaffolding in the Makefile and agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,7 @@ Layout:
 
 Building and testing:
 
-* `uv run pytest` - run unit tests
-* `uv run pytest -m integration` - run integration tests
+* `uv run pytest` - run the test suite
 * `uv run ruff check .` and `uv run ruff format .` - lint and format
 * `make` targets (e.g. `make src/linkml_map/datamodel/transformer_model.py`) regenerate the pydantic model from the YAML schema
 
@@ -33,7 +32,7 @@ Best practice:
 * always write pytest functional style rather than unittest OO style
 * use modern pytest idioms, including `@pytest.mark.parametrize` to test for combinations of inputs
 * NEVER write mock tests unless requested. I need to rely on tests to know if something breaks
-* For tests that have external dependencies, you can do `@pytest.mark.integration`
+* For tests that have external dependencies, you can do `@pytest.mark.integration` - the marker is registered in `pyproject.toml`, and nothing carries it yet
 * Do not "fix" issues by changing or weakening test conditions. Try harder, or ask questions if a test fails.
 * Avoid try/except blocks, these can mask bugs
 * Fail fast is a good principle
@@ -45,10 +44,3 @@ Best practice:
 * Always use type hints, always document methods and classes
 * **Always add tests when implementing new features or fixing bugs.** Don't wait to be asked.
 * For transformation tests, use the scaffold-based testing pattern described in `tests/README.md`
-
-## Code Patterns
-
-When modifying `ObjectTransformer.map_object`, check for `# EXTRACT:` markers.
-If touching a marked section, extract it to a private method first and add a test
-in `tests/test_transformer/test_object_transformer_new.py` using `@add_to_test_setup`.
-See issue #104 for context.

--- a/Makefile
+++ b/Makefile
@@ -7,71 +7,38 @@ SHELL := bash
 .SECONDARY:
 
 RUN = uv run
-# get values from about.yaml file
-SCHEMA_NAME = $(shell bash ./utils/get-value.sh name)
-SOURCE_SCHEMA_PATH = $(shell bash ./utils/get-value.sh source_schema_path)
-SRC = src
-DEST = project
-PYMODEL = $(SRC)/$(SCHEMA_NAME)/datamodel
+SCHEMA_NAME = linkml_map
+SOURCE_SCHEMA_PATH = src/linkml_map/datamodel/transformer_model.yaml
 DOCDIR = docs
 
-# basename of a YAML file in model/
-.PHONY: all clean
+.PHONY: help status install test test-python update-packages gendoc testdoc serve deploy-gh-doc
 
 help: status
 	@echo ""
-	@echo "make all -- makes site locally"
 	@echo "make install -- install dependencies"
-	@echo "make setup -- initial setup"
 	@echo "make test -- runs tests"
+	@echo "make gendoc -- regenerates the schema docs"
 	@echo "make testdoc -- builds docs and runs local test server"
-	@echo "make deploy -- deploys site"
+	@echo "make deploy-gh-doc -- publishes docs to GitHub Pages"
 	@echo "make update-packages -- updates dependencies"
 	@echo "make help -- show this help"
 	@echo ""
 
-status: check-config
+status:
 	@echo "Project: $(SCHEMA_NAME)"
 	@echo "Source: $(SOURCE_SCHEMA_PATH)"
 
-setup: install gen-project gendoc git-init-add
-
 install:
 	uv sync
-.PHONY: install
-
-all: gen-project gendoc
-%.yaml: gen-project
-deploy: all deploy-gh-doc
 
 # TODO: make this default
 src/linkml_map/datamodel/transformer_model.py: src/linkml_map/datamodel/transformer_model.yaml
 	# $(RUN) gen-pydantic --pydantic-version 2 $< > $@.tmp && mv $@.tmp $@
 	$(RUN) gen-pydantic --template-dir templates/pydantic $< > $@.tmp && mv $@.tmp $@
 
-# generates all project files
-# TODO: combine pydantic into this step
-gen-project: $(PYMODEL) src/linkml_map/datamodel/transformer_model.py
-	$(RUN) gen-project -X sqltable -d $(DEST) $(SOURCE_SCHEMA_PATH)
-
 test: test-python doctest
 test-python:
 	$(RUN) pytest
-test-project:
-	$(RUN) gen-project -d tmp $(SOURCE_SCHEMA_PATH)
-
-check-config:
-	@(grep my-datamodel about.yaml > /dev/null && printf "\n**Project not configured**:\n\n  - Remember to edit 'about.yaml'\n\n" || exit 0)
-
-convert-examples-to-%:
-	$(patsubst %, $(RUN) linkml-convert  % -s $(SOURCE_SCHEMA_PATH) -C Person, $(shell find src/data/examples -name "*.yaml"))
-
-examples/%.yaml: src/data/examples/%.yaml
-	$(RUN) linkml-convert -s $(SOURCE_SCHEMA_PATH) -C Person $< -o $@
-examples/%.json: src/data/examples/%.yaml
-	$(RUN) linkml-convert -s $(SOURCE_SCHEMA_PATH) -C Person $< -o $@
-examples/%.ttl: src/data/examples/%.yaml
-	$(RUN) linkml-convert -P EXAMPLE=http://example.org/ -s $(SOURCE_SCHEMA_PATH) -C Person $< -o $@
 
 # N.b. this does not update pyproject.toml
 # as of Apr 2025, uv does not have this feature
@@ -82,47 +49,20 @@ update-packages:
 # Test documentation locally
 serve: mkd-serve
 
-deploy: mkd-deploy
-
 # Deploy gh docs
 # https://github.com/linkml/linkml/issues/2193
 #deploy-gh-doc: gendoc
 deploy-gh-doc:
 	$(RUN) mkdocs gh-deploy
 
-
-
-# Python datamodel
-$(PYMODEL):
-	mkdir -p $@
-
-# docs directory
-$(DOCDIR):
-	mkdir -p $@
-
-gendoc: $(DOCDIR)
+gendoc:
 	$(RUN) gen-doc -d $(DOCDIR)/schema $(SOURCE_SCHEMA_PATH) --index-name datamodel
 
 testdoc: gendoc serve
 
 MKDOCS = $(RUN) mkdocs
+MKDOCS_ARGS =
 mkd-%:
 	$(MKDOCS) $* $(MKDOCS_ARGS)
-
-PROJECT_FOLDERS = sqlschema shex shacl protobuf prefixmap owl jsonschema jsonld graphql excel
-git-init-add: git-init git-add git-commit git-status
-git-init:
-	git init
-git-add:
-	git add .gitignore .github Makefile LICENSE *.md examples utils about.yaml mkdocs.yml uv.lock project.Makefile pyproject.toml src/linkml/*yaml src/*/datamodel/*py src/data
-	git add $(patsubst %, project/%, $(PROJECT_FOLDERS))
-git-commit:
-	git commit -m 'Initial commit' -a
-git-status:
-	git status
-
-clean:
-	rm -rf $(DEST)
-	rm -rf tmp
 
 include project.Makefile

--- a/about.yaml
+++ b/about.yaml
@@ -1,3 +1,0 @@
-name: linkml_map
-description: Datamodel for schema transformations
-source_schema_path: src/linkml_map/datamodel/transformer_model.yaml

--- a/project.Makefile
+++ b/project.Makefile
@@ -1,7 +1,4 @@
-tests/model/%.py: tests/input/%.yaml
-	$(RUN) gen-python $< > $@.tmp && mv $@.tmp $@
-
-specification: src/docs/specification/compliance.md
+specification: docs/specification/compliance.md
 
 docs/specification/compliance.md: tests/test_compliance/test_compliance_suite.py
 	mkdir -p docs/specification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ dev = [
 [project.scripts]
 linkml-map = "linkml_map.cli.cli:main"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "integration: tests that need external services or network access",
+]
+
 [tool.deptry]
 known_first_party = ["linkml_map"]
 extend_exclude = ["docs"]

--- a/utils/get-value.sh
+++ b/utils/get-value.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# get the value of a key in the about.yaml file
-# https://stackoverflow.com/questions/1221833/pipe-output-and-capture-exit-status-in-bash
-grep $1 about.yaml | sed "s/$1:[[:space:]]//" ; test ${PIPESTATUS[0]} -eq 0


### PR DESCRIPTION
Closes #299. Closes #300.

Two commits, one per issue — the Makefile and the agent instructions had rotted in the same way, and `AGENTS.md` documents make targets, so they're easier to keep honest together.

### Makefile

Roughly 35 of 128 lines were unreachable. `deploy` was defined twice (`:45` and `:85`), and since both were prerequisite-only lines make merged them silently into a target that always died on `mkdocs deploy`, which isn't a real subcommand. It's deleted rather than repaired — CI publishes through `deploy-gh-doc` directly, and a local target that force-pushes gh-pages isn't worth keeping.

Also gone: the `git-init-add` initial-commit scaffolding, the `convert-examples` rules reading a `src/data` that has never existed in this repo, `setup`, `check-config` (grepping `about.yaml` for a string renamed away at aa1851f), `all`, the `%.yaml: gen-project` pattern rule, and the `gen-project`/`test-project`/`clean` family whose `project/` output nothing consumes.

`SCHEMA_NAME` and `SOURCE_SCHEMA_PATH` are now literals, which retires `about.yaml` and `utils/get-value.sh` — a grep-based YAML parser read only by make. `MKDOCS_ARGS` is defined empty so `--warn-undefined-variables` stops firing on every `make serve`.

In `project.Makefile`, `specification` depended on `src/docs/specification/compliance.md` while the rule below builds `docs/specification/compliance.md`, so it could never run. Fixed; the dead `tests/model/%.py` rule is dropped.

Everything CI calls still resolves — `deploy-gh-doc`, `gendoc`, `test`, and the `transformer_model.py` rule — as do `specification`, `transform-to-fair`, and `doctest`. `make help` now lists only targets that work.

### Agent docs

The `# EXTRACT:` convention in Code Patterns is a ghost: `grep -rn EXTRACT src/ tests/` returns nothing, the extraction it describes was completed, and `map_object` already delegates to `_resolve_source_type`, `_perform_pivot_operation`, `_derive_slot`, and `_slot_error_context`. Section deleted.

`pytest -m integration` collected nothing and the marker wasn't registered anywhere, so any test that used it would have raised `PytestUnknownMarkWarning`. Added `[tool.pytest.ini_options]` registering the marker plus `testpaths`, and reworded the docs so they don't imply integration tests exist today.

`CONTRIBUTING.md` turned out to need nothing — bcb2b70 already moved it off black and `tox -e flake8`.

### Verification

`make test` passes (1101 passed, 4 skipped, 1 xfailed) and doctests run clean. Collection is unchanged at 1106 either side of `testpaths`, `-m integration` deselects all 1106 with no unknown-mark warning, and every surviving target was dry-run.