### PR TITLE
Exercise the per-row join fallback with an actual join

### DIFF
--- a/tests/test_transformer/test_cross_table_lookup.py
+++ b/tests/test_transformer/test_cross_table_lookup.py
@@ -1,8 +1,13 @@
 """Integration tests for cross-table join lookups (Issue #134).
 
-These tests exercise the full stack: DataLoader → LookupIndex → Bindings →
-ObjectTransformer → engine.transform_spec.  Temporary TSV files serve as
-primary and secondary tables.
+These tests exercise DataLoader → Bindings → ObjectTransformer →
+engine.transform_spec.  Temporary TSV files serve as primary and secondary
+tables.
+
+Note the joins here are subject-keyed over TSV, so ``transform_spec`` dispatches
+them to the set-based DuckDB engine; ``LookupIndex`` is not on the path despite
+being the mechanism these tests were originally written against. The per-row
+index is covered by ``test_join_engine.test_per_row_fallback_resolves_a_real_join``.
 """
 
 # ruff: noqa: ANN401, PLR2004

--- a/tests/test_transformer/test_join_engine.py
+++ b/tests/test_transformer/test_join_engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import logging
 import textwrap
+from pathlib import Path
 
 import pytest
 import yaml
@@ -18,6 +19,7 @@ from linkml_map.loaders.data_loaders import DataLoader
 from linkml_map.session import Session
 from linkml_map.transformer.engine import transform_spec
 from linkml_map.transformer.join_engine import _collect_joins, can_use_join_engine
+from linkml_map.utils.lookup_index import LookupIndex
 
 
 def _write(tmp_path, tables: dict[str, tuple[list[str], list[list]]]) -> None:
@@ -43,8 +45,10 @@ def _run(tmp_path, source_schema, spec, target_schema, source_type, tables):
 
     ``transform_spec`` routes these subject-keyed specs through the join engine (its
     default when the block is engine-capable), so this exercises the real production
-    path. Parity against the per-row lookup path is covered by the pre-existing join
-    suites, which run their human-validated expected outputs through the same dispatch.
+    path — and only that path. Parity against the per-row lookup path is covered by
+    ``test_per_row_fallback_matches_the_engine`` below, which is the one place a join
+    is driven through ``LookupIndex``; the other join suites all dispatch to the
+    engine too, so they cannot stand in for it.
     """
     _write(tmp_path, tables)
     tr = _transformer(source_schema, spec, target_schema)
@@ -679,3 +683,181 @@ def test_join_resolves_when_alias_differs_from_join_key(tmp_path):
         key=lambda r: r["id"],
     )
     assert out[0]["reading_score"] == 95.5
+
+
+# --- per-row fallback parity (issue #296) ---
+
+
+class _RecordingLookupIndex(LookupIndex):
+    """A ``LookupIndex`` that records the tables the per-row path registers.
+
+    A test-only subclass rather than a patch: ``register_table`` being called at
+    all is the signal that the per-row fallback — not the set-based engine —
+    handled a block, and that is precisely what these tests need to observe.
+    """
+
+    def __init__(self) -> None:
+        """Record registrations alongside the normal index behaviour."""
+        super().__init__()
+        self.registered: list[str] = []
+
+    def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
+        """Record *name*, then register it as usual.
+
+        :param name: Logical table name.
+        :param file_path: Path to the table's data file.
+        :param key_column: Column to index for lookups.
+        """
+        self.registered.append(name)
+        super().register_table(name, file_path, key_column)
+
+
+FALLBACK_SRC = yaml.safe_load(
+    textwrap.dedent("""\
+    id: https://example.org/fb
+    name: fb
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: fb
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      samples: {attributes: {sample_id: {identifier: true}, name: {range: string}, site_code: {range: string}}}
+      sites: {attributes: {site_code: {identifier: true}, site_name: {range: string}}}
+    """)
+)
+
+FALLBACK_TARGET = textwrap.dedent("""\
+    id: https://example.org/fbt
+    name: fbt
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: fbt
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      FlatSample: {attributes: {sample_id: {identifier: true}, name: {}, site_name: {}}}
+""")
+
+FALLBACK_SPEC = yaml.safe_load(
+    textwrap.dedent("""\
+    id: fb
+    title: fallback parity
+    class_derivations:
+      FlatSample:
+        populated_from: samples
+        joins:
+          sites: {join_on: site_code}
+        slot_derivations:
+          sample_id: {populated_from: sample_id}
+          name: {populated_from: name}
+          site_name: {expr: "{sites.site_name}"}
+    """)
+)
+
+SAMPLE_ROWS = [
+    {"sample_id": "S001", "name": "Alpha", "site_code": "SITE_A"},
+    {"sample_id": "S002", "name": "Beta", "site_code": "SITE_B"},
+    {"sample_id": "S003", "name": "Gamma", "site_code": "NO_SUCH_SITE"},
+]
+
+SITES_TABLE = ("sites", (["site_code", "site_name"], [["SITE_A", "Boston Medical"], ["SITE_B", "Seattle Clinic"]]))
+
+
+def _run_join(tmp_path, *, primary_as_yaml: bool) -> tuple[list[dict], list[str], bool]:
+    """Run the same join spec, choosing the dispatch path via the primary's file format.
+
+    The engine reads CSV/TSV/JSON only, so writing the primary as YAML makes the
+    block engine-ineligible while leaving the join itself unchanged — the per-row
+    path still reads the YAML primary through the ``DataLoader`` and the TSV
+    lookup table through ``LookupIndex``.
+
+    :param tmp_path: temporary directory for the data files
+    :param primary_as_yaml: write the primary as YAML to force the per-row path
+    :returns: sorted output rows, tables registered on the index, engine eligibility
+    :rtype: tuple[list[dict], list[str], bool]
+    """
+    _write(tmp_path, dict([SITES_TABLE]))
+    if primary_as_yaml:
+        (tmp_path / "samples.yaml").write_text(yaml.safe_dump(SAMPLE_ROWS))
+    else:
+        _write(
+            tmp_path,
+            {"samples": (["sample_id", "name", "site_code"], [list(r.values()) for r in SAMPLE_ROWS])},
+        )
+
+    tr = _transformer(FALLBACK_SRC, FALLBACK_SPEC, FALLBACK_TARGET)
+    index = _RecordingLookupIndex()
+    tr.lookup_index = index
+    loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
+    cd = tr.derived_specification.class_derivations[0]
+    eligible = can_use_join_engine(cd, loader, tr.source_schemaview)
+    out = sorted(transform_spec(tr, loader, source_type="samples"), key=lambda r: r["sample_id"])
+    return out, index.registered, eligible
+
+
+def test_per_row_fallback_resolves_a_real_join(tmp_path):
+    """The per-row ``LookupIndex`` path must resolve an actual join, not just exist.
+
+    Every other join test routes through the set-based engine, so this is the only
+    one that drives ``register_table``/``lookup_row`` with a real join (issue #296).
+    """
+    out, registered, eligible = _run_join(tmp_path, primary_as_yaml=True)
+    assert eligible is False, "YAML primary must be engine-ineligible for this test to mean anything"
+    assert registered == ["sites"], "the per-row path must have registered the joined table"
+    assert [r["site_name"] for r in out] == ["Boston Medical", "Seattle Clinic", None]
+
+
+def test_per_row_fallback_matches_the_engine(tmp_path):
+    """The two paths must agree on identical data — the parity the engine is measured against.
+
+    Same spec and same rows; only the primary's file format differs, which is what
+    selects the dispatch path.
+    """
+    engine_dir, fallback_dir = tmp_path / "engine", tmp_path / "fallback"
+    engine_dir.mkdir()
+    fallback_dir.mkdir()
+    engine_out, engine_registered, engine_eligible = _run_join(engine_dir, primary_as_yaml=False)
+    fallback_out, fallback_registered, fallback_eligible = _run_join(fallback_dir, primary_as_yaml=True)
+
+    assert engine_eligible is True
+    assert fallback_eligible is False
+    assert engine_registered == [], "the engine path must not touch the per-row index"
+    assert fallback_registered == ["sites"]
+    assert engine_out == fallback_out
+
+
+def test_engine_on_error_collects_and_continues(tmp_path):
+    """``transform_block_via_join`` must route row errors to ``on_error`` instead of raising.
+
+    The pre-existing ``on_error`` coverage runs join-free specs, which take the
+    per-row path — the engine's own error branch was never reached.
+    """
+    spec = yaml.safe_load(
+        textwrap.dedent("""\
+        id: fb
+        title: engine on_error
+        class_derivations:
+          FlatSample:
+            populated_from: samples
+            joins:
+              sites: {join_on: site_code}
+            slot_derivations:
+              sample_id: {populated_from: sample_id}
+              name: {expr: "1 / 0"}
+              site_name: {expr: "{sites.site_name}"}
+        """)
+    )
+    _write(tmp_path, dict([SITES_TABLE]))
+    _write(
+        tmp_path,
+        {"samples": (["sample_id", "name", "site_code"], [list(r.values()) for r in SAMPLE_ROWS])},
+    )
+    tr = _transformer(FALLBACK_SRC, spec, FALLBACK_TARGET)
+    loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
+    assert can_use_join_engine(tr.derived_specification.class_derivations[0], loader, tr.source_schemaview) is True
+
+    errors = []
+    results = list(transform_spec(tr, loader, source_type="samples", on_error=errors.append))
+
+    assert results == []
+    assert [e.row_index for e in errors] == [0, 1, 2]
+    assert {e.class_derivation_name for e in errors} == {"FlatSample"}

--- a/tests/test_transformer/test_join_engine.py
+++ b/tests/test_transformer/test_join_engine.py
@@ -702,14 +702,14 @@ class _RecordingLookupIndex(LookupIndex):
         self.registered: list[str] = []
 
     def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
-        """Record *name*, then register it as usual.
+        """Register the table as usual, then record *name* on success.
 
         :param name: Logical table name.
         :param file_path: Path to the table's data file.
         :param key_column: Column to index for lookups.
         """
-        self.registered.append(name)
         super().register_table(name, file_path, key_column)
+        self.registered.append(name)
 
 
 FALLBACK_SRC = yaml.safe_load(
@@ -759,7 +759,10 @@ SAMPLE_ROWS = [
     {"sample_id": "S003", "name": "Gamma", "site_code": "NO_SUCH_SITE"},
 ]
 
+SAMPLE_COLUMNS = ["sample_id", "name", "site_code"]
+
 SITES_TABLE = ("sites", (["site_code", "site_name"], [["SITE_A", "Boston Medical"], ["SITE_B", "Seattle Clinic"]]))
+SAMPLES_TABLE = ("samples", (SAMPLE_COLUMNS, [[r[c] for c in SAMPLE_COLUMNS] for r in SAMPLE_ROWS]))
 
 
 def _run_join(tmp_path, *, primary_as_yaml: bool) -> tuple[list[dict], list[str], bool]:
@@ -779,10 +782,7 @@ def _run_join(tmp_path, *, primary_as_yaml: bool) -> tuple[list[dict], list[str]
     if primary_as_yaml:
         (tmp_path / "samples.yaml").write_text(yaml.safe_dump(SAMPLE_ROWS))
     else:
-        _write(
-            tmp_path,
-            {"samples": (["sample_id", "name", "site_code"], [list(r.values()) for r in SAMPLE_ROWS])},
-        )
+        _write(tmp_path, dict([SAMPLES_TABLE]))
 
     tr = _transformer(FALLBACK_SRC, FALLBACK_SPEC, FALLBACK_TARGET)
     index = _RecordingLookupIndex()
@@ -846,11 +846,7 @@ def test_engine_on_error_collects_and_continues(tmp_path):
               site_name: {expr: "{sites.site_name}"}
         """)
     )
-    _write(tmp_path, dict([SITES_TABLE]))
-    _write(
-        tmp_path,
-        {"samples": (["sample_id", "name", "site_code"], [list(r.values()) for r in SAMPLE_ROWS])},
-    )
+    _write(tmp_path, dict([SITES_TABLE, SAMPLES_TABLE]))
     tr = _transformer(FALLBACK_SRC, spec, FALLBACK_TARGET)
     loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
     assert can_use_join_engine(tr.derived_specification.class_derivations[0], loader, tr.source_schemaview) is True


### PR DESCRIPTION
Closes #296.

`LookupIndex.register_table` ran **zero times** across the 74 join tests: every one of them dispatches to the set-based DuckDB engine, so the per-row path the engine is supposed to be at parity with was never actually driven with a join. `transform_block_via_join`'s `on_error` branch was likewise unreached — the existing `on_error` tests use join-free specs, which take the per-row path instead.

### Forcing the fallback

The engine reads CSV/TSV/JSON only. Writing the **primary** as YAML makes a block engine-ineligible while leaving the join itself untouched: the per-row path reads the YAML primary through `DataLoader` and the TSV lookup table through `LookupIndex`. That's a realistic shape (YAML source data, tabular lookup tables), and it changes the dispatch decision without contorting the spec.

I tried three other triggers first and rejected them: a joined table in YAML fails because `LookupIndex` can't read YAML either; dropping the primary from the source schema crashes in `map_object`; and a dotted `populated_from` FK chain raises unless the FK target is loadable.

### Tests

- `test_per_row_fallback_resolves_a_real_join` — asserts the block is engine-ineligible, that `sites` was actually registered on the index, and that the joined values resolve (including a miss → `None`)
- `test_per_row_fallback_matches_the_engine` — same spec and rows, only the primary's format differs; asserts the engine path registers nothing, the fallback registers `sites`, and the outputs are identical
- `test_engine_on_error_collects_and_continues` — pins the block as engine-capable, then asserts row errors reach `on_error` with row indices rather than propagating

Path observation uses a small `_RecordingLookupIndex` subclass rather than patching, so the assertions read real behaviour.

### Docstrings

Both docstrings the issue flags claimed coverage that didn't exist:

- `test_join_engine._run` said parity "is covered by the pre-existing join suites" — circular, since those suites dispatch to the engine too. Now points at the parity test.
- `test_cross_table_lookup` claimed to exercise "DataLoader → LookupIndex → Bindings". Its joins are subject-keyed TSV, so LookupIndex is not on the path. Now says so.

Full suite: 1104 passed, 4 skipped, 1 xfailed. ruff and format clean.

### Note for #298

This unblocks the join-test consolidation. The redundancy there is real but shallow — with this in place, cutting from those suites no longer removes the only thing standing in for fallback coverage.