### PR TITLE
Extract the spec normalizer out of the Transformer base class

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -811,9 +811,9 @@ def _validate_spec_merged(
         raise SystemExit(1)
 
     if emit_spec:
-        from linkml_map.transformer.transformer import Transformer
+        from linkml_map.spec_normalizer import normalize_spec
 
-        Transformer._normalize_spec_dict(merged)
+        normalize_spec(merged)
         from linkml_map.datamodel.transformer_model import TransformationSpecification
 
         spec = TransformationSpecification(**merged)

--- a/src/linkml_map/session.py
+++ b/src/linkml_map/session.py
@@ -12,6 +12,7 @@ from linkml_map import ObjectTransformer
 from linkml_map.datamodel.transformer_model import TransformationSpecification
 from linkml_map.inference.inverter import TransformationSpecificationInverter
 from linkml_map.inference.schema_mapper import SchemaMapper
+from linkml_map.spec_normalizer import normalize_spec
 from linkml_map.transformer.transformer import Transformer
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class Session:
         if isinstance(specification, TransformationSpecification):
             self.transformer_specification = specification
         elif isinstance(specification, dict):
-            Transformer._normalize_spec_dict(specification)
+            normalize_spec(specification)
             self.transformer_specification = TransformationSpecification(**specification)
         elif isinstance(specification, str):
             if "\n" in specification:

--- a/src/linkml_map/spec_normalizer.py
+++ b/src/linkml_map/spec_normalizer.py
@@ -1,0 +1,412 @@
+"""Load-time normalization of a raw transformation-specification dict.
+
+Structural fixes applied to a raw dict before Pydantic instantiation — YAML
+quirk handling, compact-key expansion, dict-to-list conversion, deprecated-field
+migration. Requires no source schema; the schema-dependent half of
+normalization (``populated_from``, ``range``, foreign-key induction) lives in
+:meth:`~linkml_map.transformer.transformer.Transformer.derived_specification`.
+
+Every entry point that turns YAML into a ``TransformationSpecification`` —
+the transformer's load methods, :class:`~linkml_map.session.Session`,
+:mod:`linkml_map.utils.loaders`, the CLI, and the validator — goes through
+:func:`normalize_spec`.
+"""
+
+import warnings
+from collections.abc import Iterator
+from typing import Any
+
+from linkml_runtime.processing.referencevalidator import ReferenceValidator
+from linkml_runtime.utils.introspection import package_schemaview
+
+from linkml_map.spec_scan import ValidationMessage, check_deprecated_fields
+from linkml_map.transformer.errors import SpecificationError
+
+
+def _iter_values_or_list(container: Any) -> Iterator[dict[str, Any]]:
+    """Yield each dict in a derivations section (dict-keyed or list form).
+
+    Doesn't expand compact-key list items — used both pre-SHAPE (where
+    compact-key items are still present and the caller is responsible for
+    expanding them via ``_expand_compact_keys`` if it needs to descend
+    into them) and post-SHAPE (where everything is already canonical).
+    """
+    if isinstance(container, dict):
+        for v in container.values():
+            if isinstance(v, dict):
+                yield v
+    elif isinstance(container, list):
+        for item in container:
+            if isinstance(item, dict):
+                yield item
+
+
+def normalize_spec(obj: dict[str, Any], *, silent: bool = False) -> list[ValidationMessage]:
+    """Normalize a raw specification dict in place. Return scan messages.
+
+    Three clean phases, ordered so the SCAN sees a canonical shape with
+    the user's original field values:
+
+    1. **SHAPE** — pure structural canonicalization, no field semantics.
+       Expands compact-key list forms everywhere they can appear
+       (top-level class/enum derivations, nested class_derivations in
+       slots, OD-inner class_derivations, PV-level lists), then runs
+       ``ReferenceValidator`` for dict↔list canonicalization and name
+       injection.
+    2. **SCAN** — :func:`linkml_map.spec_scan.check_deprecated_fields`
+       walks the canonical shape, returning ``ValidationMessage``
+       records for deprecated-field usage and ambiguous combinations.
+       Unless ``silent``, deprecation warnings fire as Python
+       ``DeprecationWarning`` and conflict errors raise
+       :class:`~linkml_map.transformer.errors.SpecificationError`.
+    3. **MIGRATE** — all field semantics in one pass:
+       ``object_derivations`` flatten, ``populated_from`` inheritance
+       from parent class, PV scalar → list, PV explicit-``None`` strip,
+       PV ``sources`` → ``populated_from`` (clearing ``sources``).
+
+    After this function, ``sources`` no longer appears on any
+    ``PermissibleValueDerivation`` — the runtime can rely on
+    ``populated_from`` as the single source of truth.
+
+    :param obj: Raw specification dict (e.g. from YAML or user code).
+    :param silent: When ``True``, neither emit warnings nor raise on
+        errors — return them in the message list instead. Used by the
+        validator path so it can surface findings as
+        ``ValidationMessage`` records.
+    :returns: A list of :class:`ValidationMessage` records from the scan.
+    """
+    # SHAPE
+    _shape_normalize(obj)
+
+    # SCAN
+    messages = check_deprecated_fields(obj)
+
+    if not silent:
+        errors = [m for m in messages if m.severity == "error"]
+        if errors:
+            raise SpecificationError("; ".join(m.message for m in errors))
+        for m in messages:
+            if m.category == "deprecated":
+                warnings.warn(m.message, DeprecationWarning, stacklevel=3)
+
+    # MIGRATE
+    _flatten_object_derivations(obj)
+    _inherit_populated_from(obj)
+    _coerce_pv_populated_from_to_list(obj)
+    _migrate_pv_sources_to_populated_from(obj)
+    _coerce_schema_refs(obj)
+
+    return messages
+
+
+def _shape_normalize(obj: dict[str, Any]) -> None:
+    """Canonicalize the structural shape of every derivation section.
+
+    Expands compact-key list forms in every derivation-section location
+    (including OD-inner class_derivations and PV-level lists, which
+    ``ReferenceValidator`` doesn't canonicalize correctly), then runs
+    ``ReferenceValidator`` for dict↔list canonicalization and name
+    injection. No field semantics are mutated.
+    """
+    _pre_shape_expand_compact_keys(obj)
+    normalizer = ReferenceValidator(package_schemaview("linkml_map.datamodel.transformer_model"))
+    normalizer.expand_all = True
+    normalized = normalize_transform_spec(obj, normalizer)
+    obj.clear()
+    obj.update(normalized)
+
+
+def normalize_transform_spec(obj: dict[str, Any], normalizer: ReferenceValidator) -> dict:
+    """Shape-canonicalize class_derivations recursively.
+
+    Pure shape work — no field migrations. ``object_derivations``
+    flattening and ``populated_from`` inheritance happen in the MIGRATE
+    phase of :func:`normalize_spec` so the SCAN phase between them sees
+    the user's original field values.
+    """
+    obj = normalizer.normalize(obj)
+
+    class_derivations = obj.get("class_derivations", [])
+    if isinstance(class_derivations, dict):
+        cd_iter = class_derivations.values()
+    else:
+        cd_iter = class_derivations
+    for class_spec in cd_iter:
+        if not isinstance(class_spec, dict):
+            continue
+        slot_derivations = class_spec.get("slot_derivations", {})
+        for slot_name, slot_spec in slot_derivations.items():
+            if slot_spec.get("value") is not None and slot_spec.get("range") is None:
+                slot_spec["range"] = "string"
+            _normalize_slot_class_derivations(slot_name, slot_spec, normalizer)
+    return obj
+
+
+def _normalize_slot_class_derivations(
+    slot_name: str,
+    slot_spec: dict[str, Any],
+    normalizer: ReferenceValidator,
+) -> None:
+    """Shape-canonicalize the ``class_derivations`` on a slot, recursively.
+
+    Two steps, applied recursively to nested slots:
+
+    1. Expand compact-key entries (``- Condition: {...}`` →
+       ``{name: Condition, ...}``).
+    2. Run the normalizer on each class derivation entry so dict-keyed
+       ``slot_derivations`` get ``name`` injected and other shape
+       canonicalization happens.
+
+    Pure shape — no field semantics. ``object_derivations`` flattening
+    and ``populated_from`` inheritance live in the MIGRATE phase of
+    :func:`normalize_spec`, not here, so the SCAN phase sees the user's
+    original field values.
+    """
+    slot_cd = slot_spec.get("class_derivations")
+    if not isinstance(slot_cd, list):
+        return
+
+    _expand_compact_keys(slot_cd)
+
+    for cd_entry in slot_cd:
+        if not isinstance(cd_entry, dict):
+            continue
+        normalized = normalizer.normalize(cd_entry)
+        cd_entry.clear()
+        cd_entry.update(normalized)
+        for nested_name, nested_sd in cd_entry.get("slot_derivations", {}).items():
+            if isinstance(nested_sd, dict):
+                _normalize_slot_class_derivations(nested_name, nested_sd, normalizer)
+
+
+def _pre_shape_expand_compact_keys(obj: dict[str, Any]) -> None:
+    """Recursively expand compact-key list forms before ReferenceValidator.
+
+    Compact-key list form (``[{Name: {body}}]``) is a linkml-map convention,
+    not a documented LinkML collection form. ``ReferenceValidator``
+    therefore doesn't canonicalize it consistently — list-typed fields
+    (top-level class_derivations) are left as-is, and dict-typed fields
+    (permissible_value_derivations) get mangled to ``{None: ...}``. This
+    pre-pass converts compact-key items to explicit-name form everywhere
+    the linkml-map schema accepts a derivation section, so RV sees only
+    LinkML-canonical input.
+
+    See https://github.com/linkml/linkml/issues/3529 for the upstream
+    behavior. The local pre-expansion makes us independent of how (or
+    whether) that gets resolved.
+    """
+    _preprocess_class_derivations(obj)
+    _preprocess_enum_derivations(obj)
+    for cd in _iter_values_or_list(obj.get("class_derivations")):
+        _expand_compact_keys_in_class_deriv(cd)
+
+
+def _expand_compact_keys_in_class_deriv(cd: dict[str, Any]) -> None:
+    """Expand compact-key list forms in a class derivation, recursively."""
+    for sd in _iter_values_or_list(cd.get("slot_derivations")):
+        # Slot's own nested class_derivations (list-with-compact-keys form)
+        nested_cds = sd.get("class_derivations")
+        if isinstance(nested_cds, list):
+            _expand_compact_keys(nested_cds)
+        for ncd in _iter_values_or_list(nested_cds):
+            _expand_compact_keys_in_class_deriv(ncd)
+        # OD-inner class_derivations (deprecated form; flattened in MIGRATE)
+        ods = sd.get("object_derivations")
+        if isinstance(ods, list):
+            for od in ods:
+                if not isinstance(od, dict):
+                    continue
+                od_cds = od.get("class_derivations")
+                if isinstance(od_cds, list):
+                    _expand_compact_keys(od_cds)
+                for ncd in _iter_values_or_list(od_cds):
+                    _expand_compact_keys_in_class_deriv(ncd)
+
+
+def _preprocess_enum_derivations(obj: dict[str, Any]) -> None:
+    """Pre-process top-level enum_derivations and their PV sections.
+
+    Handles two compact-key cases ReferenceValidator doesn't:
+    list-form enum_derivations with ``{Name: {...}}`` items, and
+    list-form permissible_value_derivations with the same shape (which
+    RV otherwise mangles into ``{None: ...}``).
+    """
+    eds = obj.get("enum_derivations")
+    if isinstance(eds, dict):
+        for k, v in eds.items():
+            if v is None:
+                eds[k] = {}
+    elif isinstance(eds, list):
+        _expand_compact_keys(eds)
+    for ed in _iter_values_or_list(obj.get("enum_derivations")):
+        pvs = ed.get("permissible_value_derivations")
+        if isinstance(pvs, list):
+            _expand_compact_keys(pvs)
+
+
+def _preprocess_class_derivations(obj: dict[str, Any]) -> None:
+    """Pre-process top-level class_derivations before ReferenceValidator normalization.
+
+    Handles two cases:
+    1. Dict format with None values (e.g. ``Entity:`` with no body) — replace
+       with empty dicts so ReferenceValidator.ensure_list doesn't choke.
+    2. List format with compact keys — delegate to ``_expand_compact_keys``.
+    """
+    cd = obj.get("class_derivations")
+    if isinstance(cd, dict):
+        for k, v in cd.items():
+            if v is None:
+                cd[k] = {}
+    elif isinstance(cd, list):
+        _expand_compact_keys(cd)
+
+
+def _expand_compact_keys(items: list[dict[str, Any]]) -> None:
+    """Expand YAML compact-key dicts in a list in place.
+
+    Converts ``{"Condition": {"populated_from": "x"}}`` →
+    ``{"name": "Condition", "populated_from": "x"}``.
+    Skips items whose sole key is ``"name"`` (already expanded).
+    """
+    for i, item in enumerate(items):
+        if isinstance(item, dict) and len(item) == 1:
+            key, val = next(iter(item.items()))
+            if key != "name" and isinstance(val, dict | type(None)):
+                expanded = val if val is not None else {}
+                expanded.setdefault("name", key)
+                items[i] = expanded
+
+
+def _flatten_object_derivations(obj: dict[str, Any]) -> None:
+    """Flatten ``object_derivations`` into ``class_derivations`` on every slot.
+
+    Conflicting specs (both ``object_derivations`` and ``class_derivations``
+    set) are caught upstream by the SCAN phase as ``severity="error"``,
+    so this function assumes a non-conflicting input.
+    """
+    for cd in _iter_values_or_list(obj.get("class_derivations")):
+        _flatten_ods_in_class_deriv(cd)
+
+
+def _flatten_ods_in_class_deriv(cd: dict[str, Any]) -> None:
+    """Recursively walk a class derivation, flattening OD on each slot."""
+    for sd in _iter_values_or_list(cd.get("slot_derivations")):
+        ods = sd.get("object_derivations")
+        if ods:
+            flattened: list[dict[str, Any]] = []
+            for od in ods:
+                if not isinstance(od, dict):
+                    continue
+                od_cd = od.get("class_derivations", {})
+                if isinstance(od_cd, dict):
+                    for name, body in od_cd.items():
+                        entry = body if isinstance(body, dict) else {}
+                        entry.setdefault("name", name)
+                        flattened.append(entry)
+                elif isinstance(od_cd, list):
+                    flattened.extend(od_cd)
+            sd["class_derivations"] = flattened
+            del sd["object_derivations"]
+        for ncd in _iter_values_or_list(sd.get("class_derivations")):
+            _flatten_ods_in_class_deriv(ncd)
+
+
+def _inherit_populated_from(obj: dict[str, Any]) -> None:
+    """Propagate ``populated_from`` from parent class down to nested CDs.
+
+    Walks each class_derivation's slot_derivations.class_derivations; if
+    a nested CD doesn't set ``populated_from``, it inherits from the
+    outer class's value. Recurses through arbitrarily deep nesting.
+    """
+    for cd in _iter_values_or_list(obj.get("class_derivations")):
+        _inherit_pf_in_slots(cd.get("slot_derivations"), cd.get("populated_from"))
+
+
+def _inherit_pf_in_slots(slots: Any, parent_pf: str | None) -> None:
+    """Recursively inherit populated_from into nested class_derivations."""
+    for sd in _iter_values_or_list(slots):
+        for ncd in _iter_values_or_list(sd.get("class_derivations")):
+            if not ncd.get("populated_from") and parent_pf:
+                ncd["populated_from"] = parent_pf
+            _inherit_pf_in_slots(ncd.get("slot_derivations"), ncd.get("populated_from"))
+
+
+def _iter_pv_derivations(obj: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield each PermissibleValueDerivation dict in ``obj`` for in-place mutation."""
+    eds = obj.get("enum_derivations")
+    if isinstance(eds, dict):
+        ed_iter: Any = eds.values()
+    elif isinstance(eds, list):
+        ed_iter = eds
+    else:
+        return
+    for ed in ed_iter:
+        if not isinstance(ed, dict):
+            continue
+        pvds = ed.get("permissible_value_derivations")
+        if isinstance(pvds, dict):
+            pvd_iter: Any = pvds.values()
+        elif isinstance(pvds, list):
+            pvd_iter = pvds
+        else:
+            continue
+        for pvd in pvd_iter:
+            if isinstance(pvd, dict):
+                yield pvd
+
+
+def _coerce_pv_populated_from_to_list(obj: dict[str, Any]) -> None:
+    """Coerce ``populated_from`` to a list on each PV deriv.
+
+    Input shapes handled:
+
+    * Scalar string: wrapped to a one-element list (user convenience that
+      pydantic would otherwise reject for a multivalued field).
+    * Explicit ``None`` or a list whose every element is ``None``
+      (``populated_from:`` with no YAML value, possibly already wrapped to
+      ``[None]`` by ``ReferenceValidator``): the key is removed so pydantic
+      uses the ``default_factory=list`` default — treats "explicitly set to
+      nothing" as "unset". Empty strings and other falsy-but-not-None
+      values are kept (a user may legitimately map to the empty-string PV).
+    * List: left as-is.
+    """
+    for pvd in _iter_pv_derivations(obj):
+        if "populated_from" not in pvd:
+            continue
+        pf = pvd["populated_from"]
+        if pf is None or (isinstance(pf, list) and all(x is None for x in pf)):
+            del pvd["populated_from"]
+        elif isinstance(pf, str):
+            pvd["populated_from"] = [pf]
+
+
+def _migrate_pv_sources_to_populated_from(obj: dict[str, Any]) -> None:
+    """Move deprecated ``sources`` into ``populated_from`` on PV derivs.
+
+    Applied after the pre-normalize scan has already detected and reported
+    any ``sources`` usage and any ``sources`` + ``populated_from`` conflicts.
+    For each PV deriv with ``sources`` set, copies into ``populated_from``
+    (if not already set) and clears the ``sources`` key. A scalar string
+    is wrapped to a one-element list rather than exploded into characters
+    (defends against ``sources: "light_red"`` typos). Post-condition: no
+    PV has ``sources`` set. The runtime can therefore rely on
+    ``populated_from`` as the single source of truth and ignore ``sources``.
+    """
+    for pvd in _iter_pv_derivations(obj):
+        srcs = pvd.pop("sources", None)
+        if srcs and not pvd.get("populated_from"):
+            pvd["populated_from"] = [srcs] if isinstance(srcs, str) else list(srcs)
+
+
+def _coerce_schema_refs(obj: dict[str, Any]) -> None:
+    """Coerce bare-string ``source_schema``/``target_schema`` to object form.
+
+    The original spec form was a bare string (e.g. ``source_schema: my.yaml``);
+    the field now ranges over ``SchemaReference``. For backward compatibility
+    a string is rewritten to ``{"name": <string>}`` so legacy specs keep
+    loading. The pre-normalize scan reports the string form as deprecated.
+    """
+    for schema_field in ("source_schema", "target_schema"):
+        val = obj.get(schema_field)
+        if isinstance(val, str):
+            obj[schema_field] = {"name": val}

--- a/src/linkml_map/spec_scan.py
+++ b/src/linkml_map/spec_scan.py
@@ -1,0 +1,221 @@
+"""The SCAN phase: deprecated-field detection over a raw specification dict.
+
+Runs between the SHAPE and MIGRATE phases of
+:func:`linkml_map.spec_normalizer.normalize_spec`, so the dict it sees is
+structurally canonical but still carries the user's original field values.
+
+This module deliberately depends on nothing but the standard library:
+:mod:`linkml_map.spec_normalizer` and :mod:`linkml_map.validator` both build
+on it, so it has to sit at the bottom of that stack.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass
+class ValidationMessage:
+    """A single validation finding with severity and location context.
+
+    ``category`` is an optional tag that downstream consumers can use to
+    group or filter messages. The validator currently emits ``"deprecated"``
+    for warnings about deprecated field usage; other categories may be
+    added in the future.
+    """
+
+    severity: Literal["error", "warning", "info"]
+    path: str
+    message: str
+    category: str | None = None
+
+    def __str__(self) -> str:
+        return f"{self.path}: [{self.severity}] {self.message}"
+
+
+def iter_derivation_dicts(raw: Any) -> list[dict[str, Any]]:
+    """Normalize a derivations section (dict or list) to a list of dicts.
+
+    Assumes the SHAPE phase of
+    :func:`linkml_map.spec_normalizer.normalize_spec` has already
+    canonicalized compact-key list items, so callers only need to handle
+    dict-keyed and explicit-name list forms here.
+    """
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    if isinstance(raw, dict):
+        result: list[dict[str, Any]] = []
+        for name, body in raw.items():
+            d = dict(body) if isinstance(body, dict) else {}
+            d.setdefault("name", name)
+            result.append(d)
+        return result
+    return []
+
+
+def check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
+    """Scan a spec dict for deprecated-field usage and ambiguous combinations.
+
+    Runs in the SCAN phase of
+    :func:`linkml_map.spec_normalizer.normalize_spec` — after SHAPE (which
+    runs ``ReferenceValidator.normalize()`` and the local compact-key
+    pre-expansion) and before MIGRATE (which flattens
+    ``object_derivations``, inherits ``populated_from``, and rewrites PV
+    ``sources``). So the dict the scan sees is structurally canonical
+    (dict-keyed or explicit-name list, no compact-key items) but the
+    deprecated field values are still as the user wrote them.
+
+    Flags:
+
+    * ``sources`` on ``ClassDerivation`` / ``SlotDerivation`` /
+      ``EnumDerivation`` / ``PermissibleValueDerivation`` — replaced by
+      ``populated_from``. Severity: warning, category: deprecated.
+    * ``derived_from`` on ``SlotDerivation`` — ignored by the runtime
+      and removable. Severity: warning, category: deprecated.
+    * ``object_derivations`` on ``SlotDerivation`` — flattened into
+      ``class_derivations`` at load time. Severity: warning, category:
+      deprecated.
+    * ``populated_from`` **and** ``sources`` both set on the same
+      ``PermissibleValueDerivation`` — ambiguous, the user almost
+      certainly didn't mean both. Severity: error.
+    * ``object_derivations`` **and** ``class_derivations`` both set on
+      the same ``SlotDerivation`` — ambiguous. Severity: error.
+    * ``source_schema`` / ``target_schema`` set to a bare string — the
+      original form, now superseded by the ``SchemaReference`` object
+      form (``{name: ...}``). Coerced at load time. Severity: warning,
+      category: deprecated.
+
+    ``sources`` deprecation findings are collapsed to one message per
+    (deprecation, derivation type) pair to keep output readable on
+    large specs; per-entry messages are emitted for the other categories.
+
+    :param data: A spec dict post-SHAPE, pre-MIGRATE. Derivation sections
+        are dict-keyed or explicit-name list (no compact-key items).
+    :returns: A list of validation messages — warnings for deprecations,
+        errors for ambiguous combinations.
+    """
+    messages: list[ValidationMessage] = []
+    sources_counts: dict[str, list[str]] = {
+        "ClassDerivation": [],
+        "SlotDerivation": [],
+        "EnumDerivation": [],
+        "PermissibleValueDerivation": [],
+    }
+    derived_from_names: list[str] = []
+    object_derivation_names: list[str] = []
+
+    for cd in iter_derivation_dicts(data.get("class_derivations")):
+        cd_name = cd.get("name", "<unnamed>")
+        if cd.get("sources"):
+            sources_counts["ClassDerivation"].append(cd_name)
+        for sd in iter_derivation_dicts(cd.get("slot_derivations")):
+            sd_name = sd.get("name", "<unnamed>")
+            if sd.get("sources"):
+                sources_counts["SlotDerivation"].append(sd_name)
+            if sd.get("derived_from"):
+                derived_from_names.append(sd_name)
+            if sd.get("object_derivations"):
+                object_derivation_names.append(sd_name)
+                if sd.get("class_derivations"):
+                    messages.append(
+                        ValidationMessage(
+                            severity="error",
+                            path=f"$.class_derivations[{cd_name}].slot_derivations[{sd_name}]",
+                            message=(
+                                f"SlotDerivation '{sd_name}' sets both 'object_derivations' "
+                                f"and 'class_derivations'. Remove 'object_derivations' and "
+                                f"use 'class_derivations' only."
+                            ),
+                        )
+                    )
+
+    for ed in iter_derivation_dicts(data.get("enum_derivations")):
+        ed_name = ed.get("name", "<unnamed>")
+        if ed.get("sources"):
+            sources_counts["EnumDerivation"].append(ed_name)
+        for pvd in iter_derivation_dicts(ed.get("permissible_value_derivations")):
+            pvd_name = pvd.get("name", "<unnamed>")
+            if pvd.get("sources"):
+                sources_counts["PermissibleValueDerivation"].append(pvd_name)
+                if pvd.get("populated_from"):
+                    messages.append(
+                        ValidationMessage(
+                            severity="error",
+                            path=(f"$.enum_derivations[{ed_name}].permissible_value_derivations[{pvd_name}]"),
+                            message=(
+                                f"PermissibleValueDerivation '{pvd_name}' sets both "
+                                f"'populated_from' and 'sources'. These are alternative "
+                                f"spellings of the same field; set only 'populated_from' "
+                                f"(which now accepts a list)."
+                            ),
+                        )
+                    )
+
+    for deriv_type, names in sources_counts.items():
+        if names:
+            preview = ", ".join(names[:5])
+            suffix = f" (and {len(names) - 5} more)" if len(names) > 5 else ""
+            messages.append(
+                ValidationMessage(
+                    severity="warning",
+                    category="deprecated",
+                    path=f"$.{deriv_type}",
+                    message=(
+                        f"{len(names)} {deriv_type}(s) use 'sources', which is deprecated: "
+                        f"{preview}{suffix}. Use 'populated_from' instead. "
+                        f"'sources' will be removed in a future version."
+                    ),
+                )
+            )
+
+    if object_derivation_names:
+        preview = ", ".join(object_derivation_names[:5])
+        suffix = f" (and {len(object_derivation_names) - 5} more)" if len(object_derivation_names) > 5 else ""
+        messages.append(
+            ValidationMessage(
+                severity="warning",
+                category="deprecated",
+                path="$.SlotDerivation",
+                message=(
+                    f"{len(object_derivation_names)} SlotDerivation(s) use 'object_derivations', "
+                    f"which is deprecated and flattened into 'class_derivations' at load time: "
+                    f"{preview}{suffix}. Use list-based 'class_derivations' instead. "
+                    f"'object_derivations' will be removed in a future version. "
+                    f"See https://github.com/linkml/linkml-map/issues/112"
+                ),
+            )
+        )
+
+    if derived_from_names:
+        preview = ", ".join(derived_from_names[:5])
+        suffix = f" (and {len(derived_from_names) - 5} more)" if len(derived_from_names) > 5 else ""
+        messages.append(
+            ValidationMessage(
+                severity="warning",
+                category="deprecated",
+                path="$.SlotDerivation",
+                message=(
+                    f"{len(derived_from_names)} SlotDerivation(s) use 'derived_from', "
+                    f"which is deprecated and ignored by the runtime: "
+                    f"{preview}{suffix}. This field can be removed — source slot "
+                    f"dependencies are derivable from 'expr'. 'derived_from' will "
+                    f"be removed in a future version."
+                ),
+            )
+        )
+
+    for schema_field in ("source_schema", "target_schema"):
+        if isinstance(data.get(schema_field), str):
+            messages.append(
+                ValidationMessage(
+                    severity="warning",
+                    category="deprecated",
+                    path=f"$.{schema_field}",
+                    message=(
+                        f"'{schema_field}' is set to a bare string, which is deprecated. "
+                        f"Use the SchemaReference object form '{schema_field}: {{name: ...}}'. "
+                        f"The string form will be removed in a future version."
+                    ),
+                )
+            )
+
+    return messages

--- a/src/linkml_map/transformer/errors.py
+++ b/src/linkml_map/transformer/errors.py
@@ -14,7 +14,7 @@ class SpecificationError(ValueError):
     both ``populated_from`` and ``sources`` on the same derivation, or
     setting both ``object_derivations`` and ``class_derivations`` on a
     slot). Subclasses ``ValueError`` for backward compatibility with
-    callers that already catch ``ValueError`` from ``_normalize_spec_dict``.
+    callers that already catch ``ValueError`` from ``normalize_spec``.
     """
 
 

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -1331,7 +1331,7 @@ class ObjectTransformer(Transformer):
                     msg = (
                         f"PermissibleValueDerivation '{pv_deriv.name}' has 'sources' set; "
                         "this should have been migrated to 'populated_from' during spec load. "
-                        "Did the spec bypass Transformer._normalize_spec_dict?"
+                        "Did the spec bypass linkml_map.spec_normalizer.normalize_spec?"
                     )
                     raise SpecificationError(msg)
                 if pv_deriv.populated_from and source_value in pv_deriv.populated_from:

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -1,9 +1,7 @@
 """Transformers transform objects from one class to another using a transformation specification."""
 
 import logging
-import warnings
 from abc import ABC
-from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,8 +10,6 @@ from typing import Any
 import yaml
 from curies import Converter
 from linkml_runtime import SchemaView
-from linkml_runtime.processing.referencevalidator import ReferenceValidator
-from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from pydantic import BaseModel
 
@@ -26,6 +22,7 @@ from linkml_map.datamodel.transformer_model import (
     TransformationSpecification,
 )
 from linkml_map.inference.inference import induce_missing_values
+from linkml_map.spec_normalizer import normalize_spec
 from linkml_map.utils.eval_utils import FUNCTIONS, INJECTED_EVAL_NAMES
 from linkml_map.utils.expression_locations import (
     extract_braced_reference_roots,
@@ -36,24 +33,6 @@ from linkml_map.utils.join_utils import infer_join_key
 from linkml_map.utils.schema_patch import apply_schema_patch
 
 logger = logging.getLogger(__name__)
-
-
-def _iter_values_or_list(container: Any) -> Iterator[dict[str, Any]]:
-    """Yield each dict in a derivations section (dict-keyed or list form).
-
-    Doesn't expand compact-key list items — used both pre-SHAPE (where
-    compact-key items are still present and the caller is responsible for
-    expanding them via ``_expand_compact_keys`` if it needs to descend
-    into them) and post-SHAPE (where everything is already canonical).
-    """
-    if isinstance(container, dict):
-        for v in container.values():
-            if isinstance(v, dict):
-                yield v
-    elif isinstance(container, list):
-        for item in container:
-            if isinstance(item, dict):
-                yield item
 
 
 OBJECT_TYPE = dict[str, Any] | BaseModel | YAMLRoot
@@ -73,12 +52,13 @@ class Transformer(ABC):
 
     Specification normalization has two phases:
 
-    1. **Load-time normalization** (``_normalize_spec_dict``): Structural fixes
+    1. **Load-time normalization**
+       (:func:`~linkml_map.spec_normalizer.normalize_spec`): Structural fixes
        applied to a raw dict before Pydantic instantiation — YAML quirk handling,
        ``$ref`` expansion, dict-to-list conversion. Does not require a source schema.
        All entry points (``load_transformer_specification``,
        ``create_transformer_specification``, ``Session``, ``loaders``) go through
-       this single method.
+       that single function.
 
     2. **Schema-bind-time induction** (``derived_specification``): Semantic defaults
        inferred from the source schema — ``populated_from``, ``range``, foreign-key
@@ -123,7 +103,7 @@ class Transformer(ABC):
 
     Populated by the three load methods (``load_transformer_specification``,
     ``load_transformer_specifications``, ``create_transformer_specification``)
-    with the ``ValidationMessage`` list returned by ``_normalize_spec_dict``.
+    with the ``ValidationMessage`` list returned by ``normalize_spec``.
     Pre-flight validation reads these instead of re-scanning the post-migration
     spec, so deprecations whose source fields were cleared by normalization
     (e.g., ``object_derivations``, PV ``sources``) are still surfaced.
@@ -171,7 +151,7 @@ class Transformer(ABC):
         """
         with open(path) as f:
             obj = yaml.safe_load(f)
-            self.spec_messages = self._normalize_spec_dict(obj)
+            self.spec_messages = normalize_spec(obj)
             self.specification = TransformationSpecification(**obj)
 
     def load_transformer_specifications(self, paths: tuple[str | Path, ...]) -> None:
@@ -187,383 +167,8 @@ class Transformer(ABC):
         from linkml_map.utils.spec_merge import load_and_merge_specs
 
         obj = load_and_merge_specs(paths)
-        self.spec_messages = self._normalize_spec_dict(obj)
+        self.spec_messages = normalize_spec(obj)
         self.specification = TransformationSpecification(**obj)
-
-    @classmethod
-    def normalize_transform_spec(cls, obj: dict[str, Any], normalizer: ReferenceValidator) -> dict:
-        """Shape-canonicalize class_derivations recursively.
-
-        Pure shape work — no field migrations. ``object_derivations``
-        flattening and ``populated_from`` inheritance happen in the MIGRATE
-        phase of :meth:`_normalize_spec_dict` so the SCAN phase between
-        them sees the user's original field values.
-        """
-        obj = normalizer.normalize(obj)
-
-        class_derivations = obj.get("class_derivations", [])
-        if isinstance(class_derivations, dict):
-            cd_iter = class_derivations.values()
-        else:
-            cd_iter = class_derivations
-        for class_spec in cd_iter:
-            if not isinstance(class_spec, dict):
-                continue
-            slot_derivations = class_spec.get("slot_derivations", {})
-            for slot_name, slot_spec in slot_derivations.items():
-                if slot_spec.get("value") is not None and slot_spec.get("range") is None:
-                    slot_spec["range"] = "string"
-                cls._normalize_slot_class_derivations(slot_name, slot_spec, normalizer)
-        return obj
-
-    @classmethod
-    def _normalize_slot_class_derivations(
-        cls,
-        slot_name: str,
-        slot_spec: dict[str, Any],
-        normalizer: ReferenceValidator,
-    ) -> None:
-        """Shape-canonicalize the ``class_derivations`` on a slot, recursively.
-
-        Two steps, applied recursively to nested slots:
-
-        1. Expand compact-key entries (``- Condition: {...}`` →
-           ``{name: Condition, ...}``).
-        2. Run the normalizer on each class derivation entry so dict-keyed
-           ``slot_derivations`` get ``name`` injected and other shape
-           canonicalization happens.
-
-        Pure shape — no field semantics. ``object_derivations`` flattening
-        and ``populated_from`` inheritance live in the MIGRATE phase of
-        :meth:`_normalize_spec_dict`, not here, so the SCAN phase sees the
-        user's original field values.
-        """
-        slot_cd = slot_spec.get("class_derivations")
-        if not isinstance(slot_cd, list):
-            return
-
-        cls._expand_compact_keys(slot_cd)
-
-        for cd_entry in slot_cd:
-            if not isinstance(cd_entry, dict):
-                continue
-            normalized = normalizer.normalize(cd_entry)
-            cd_entry.clear()
-            cd_entry.update(normalized)
-            for nested_name, nested_sd in cd_entry.get("slot_derivations", {}).items():
-                if isinstance(nested_sd, dict):
-                    cls._normalize_slot_class_derivations(nested_name, nested_sd, normalizer)
-
-    @classmethod
-    def _normalize_spec_dict(cls, obj: dict[str, Any], *, silent: bool = False) -> list[Any]:
-        """Normalize a raw specification dict in place. Return scan messages.
-
-        Three clean phases, ordered so the SCAN sees a canonical shape with
-        the user's original field values:
-
-        1. **SHAPE** — pure structural canonicalization, no field semantics.
-           Expands compact-key list forms everywhere they can appear
-           (top-level class/enum derivations, nested class_derivations in
-           slots, OD-inner class_derivations, PV-level lists), then runs
-           ``ReferenceValidator`` for dict↔list canonicalization and name
-           injection.
-        2. **SCAN** — :func:`linkml_map.validator.check_deprecated_fields`
-           walks the canonical shape, returning ``ValidationMessage``
-           records for deprecated-field usage and ambiguous combinations.
-           Unless ``silent``, deprecation warnings fire as Python
-           ``DeprecationWarning`` and conflict errors raise
-           :class:`~linkml_map.transformer.errors.SpecificationError`.
-        3. **MIGRATE** — all field semantics in one pass:
-           ``object_derivations`` flatten, ``populated_from`` inheritance
-           from parent class, PV scalar → list, PV explicit-``None`` strip,
-           PV ``sources`` → ``populated_from`` (clearing ``sources``).
-
-        After this method, ``sources`` no longer appears on any
-        ``PermissibleValueDerivation`` — the runtime can rely on
-        ``populated_from`` as the single source of truth.
-
-        :param obj: Raw specification dict (e.g. from YAML or user code).
-        :param silent: When ``True``, neither emit warnings nor raise on
-            errors — return them in the message list instead. Used by the
-            validator path so it can surface findings as
-            ``ValidationMessage`` records.
-        :returns: A list of :class:`ValidationMessage` records from the scan.
-        """
-        from linkml_map.transformer.errors import SpecificationError
-        from linkml_map.validator import check_deprecated_fields
-
-        # SHAPE
-        cls._shape_normalize(obj)
-
-        # SCAN
-        messages = check_deprecated_fields(obj)
-
-        if not silent:
-            errors = [m for m in messages if m.severity == "error"]
-            if errors:
-                raise SpecificationError("; ".join(m.message for m in errors))
-            for m in messages:
-                if m.category == "deprecated":
-                    warnings.warn(m.message, DeprecationWarning, stacklevel=3)
-
-        # MIGRATE
-        cls._flatten_object_derivations(obj)
-        cls._inherit_populated_from(obj)
-        cls._coerce_pv_populated_from_to_list(obj)
-        cls._migrate_pv_sources_to_populated_from(obj)
-        cls._coerce_schema_refs(obj)
-
-        return messages
-
-    @staticmethod
-    def _coerce_schema_refs(obj: dict[str, Any]) -> None:
-        """Coerce bare-string ``source_schema``/``target_schema`` to object form.
-
-        The original spec form was a bare string (e.g. ``source_schema: my.yaml``);
-        the field now ranges over ``SchemaReference``. For backward compatibility
-        a string is rewritten to ``{"name": <string>}`` so legacy specs keep
-        loading. The pre-normalize scan reports the string form as deprecated.
-        """
-        for schema_field in ("source_schema", "target_schema"):
-            val = obj.get(schema_field)
-            if isinstance(val, str):
-                obj[schema_field] = {"name": val}
-
-    @classmethod
-    def _shape_normalize(cls, obj: dict[str, Any]) -> None:
-        """Canonicalize the structural shape of every derivation section.
-
-        Expands compact-key list forms in every derivation-section location
-        (including OD-inner class_derivations and PV-level lists, which
-        ``ReferenceValidator`` doesn't canonicalize correctly), then runs
-        ``ReferenceValidator`` for dict↔list canonicalization and name
-        injection. No field semantics are mutated.
-        """
-        cls._pre_shape_expand_compact_keys(obj)
-        normalizer = ReferenceValidator(package_schemaview("linkml_map.datamodel.transformer_model"))
-        normalizer.expand_all = True
-        normalized = cls.normalize_transform_spec(obj, normalizer)
-        obj.clear()
-        obj.update(normalized)
-
-    @classmethod
-    def _pre_shape_expand_compact_keys(cls, obj: dict[str, Any]) -> None:
-        """Recursively expand compact-key list forms before ReferenceValidator.
-
-        Compact-key list form (``[{Name: {body}}]``) is a linkml-map convention,
-        not a documented LinkML collection form. ``ReferenceValidator``
-        therefore doesn't canonicalize it consistently — list-typed fields
-        (top-level class_derivations) are left as-is, and dict-typed fields
-        (permissible_value_derivations) get mangled to ``{None: ...}``. This
-        pre-pass converts compact-key items to explicit-name form everywhere
-        the linkml-map schema accepts a derivation section, so RV sees only
-        LinkML-canonical input.
-
-        See https://github.com/linkml/linkml/issues/3529 for the upstream
-        behavior. The local pre-expansion makes us independent of how (or
-        whether) that gets resolved.
-        """
-        cls._preprocess_class_derivations(obj)
-        cls._preprocess_enum_derivations(obj)
-        for cd in _iter_values_or_list(obj.get("class_derivations")):
-            cls._expand_compact_keys_in_class_deriv(cd)
-
-    @classmethod
-    def _expand_compact_keys_in_class_deriv(cls, cd: dict[str, Any]) -> None:
-        """Expand compact-key list forms in a class derivation, recursively."""
-        for sd in _iter_values_or_list(cd.get("slot_derivations")):
-            # Slot's own nested class_derivations (list-with-compact-keys form)
-            nested_cds = sd.get("class_derivations")
-            if isinstance(nested_cds, list):
-                cls._expand_compact_keys(nested_cds)
-            for ncd in _iter_values_or_list(nested_cds):
-                cls._expand_compact_keys_in_class_deriv(ncd)
-            # OD-inner class_derivations (deprecated form; flattened in MIGRATE)
-            ods = sd.get("object_derivations")
-            if isinstance(ods, list):
-                for od in ods:
-                    if not isinstance(od, dict):
-                        continue
-                    od_cds = od.get("class_derivations")
-                    if isinstance(od_cds, list):
-                        cls._expand_compact_keys(od_cds)
-                    for ncd in _iter_values_or_list(od_cds):
-                        cls._expand_compact_keys_in_class_deriv(ncd)
-
-    @staticmethod
-    def _preprocess_enum_derivations(obj: dict[str, Any]) -> None:
-        """Pre-process top-level enum_derivations and their PV sections.
-
-        Handles two compact-key cases ReferenceValidator doesn't:
-        list-form enum_derivations with ``{Name: {...}}`` items, and
-        list-form permissible_value_derivations with the same shape (which
-        RV otherwise mangles into ``{None: ...}``).
-        """
-        eds = obj.get("enum_derivations")
-        if isinstance(eds, dict):
-            for k, v in eds.items():
-                if v is None:
-                    eds[k] = {}
-        elif isinstance(eds, list):
-            Transformer._expand_compact_keys(eds)
-        for ed in _iter_values_or_list(obj.get("enum_derivations")):
-            pvs = ed.get("permissible_value_derivations")
-            if isinstance(pvs, list):
-                Transformer._expand_compact_keys(pvs)
-
-    @classmethod
-    def _flatten_object_derivations(cls, obj: dict[str, Any]) -> None:
-        """Flatten ``object_derivations`` into ``class_derivations`` on every slot.
-
-        Conflicting specs (both ``object_derivations`` and ``class_derivations``
-        set) are caught upstream by the SCAN phase as ``severity="error"``,
-        so this method assumes a non-conflicting input.
-        """
-        for cd in _iter_values_or_list(obj.get("class_derivations")):
-            cls._flatten_ods_in_class_deriv(cd)
-
-    @classmethod
-    def _flatten_ods_in_class_deriv(cls, cd: dict[str, Any]) -> None:
-        """Recursively walk a class derivation, flattening OD on each slot."""
-        for sd in _iter_values_or_list(cd.get("slot_derivations")):
-            ods = sd.get("object_derivations")
-            if ods:
-                flattened: list[dict[str, Any]] = []
-                for od in ods:
-                    if not isinstance(od, dict):
-                        continue
-                    od_cd = od.get("class_derivations", {})
-                    if isinstance(od_cd, dict):
-                        for name, body in od_cd.items():
-                            entry = body if isinstance(body, dict) else {}
-                            entry.setdefault("name", name)
-                            flattened.append(entry)
-                    elif isinstance(od_cd, list):
-                        flattened.extend(od_cd)
-                sd["class_derivations"] = flattened
-                del sd["object_derivations"]
-            for ncd in _iter_values_or_list(sd.get("class_derivations")):
-                cls._flatten_ods_in_class_deriv(ncd)
-
-    @classmethod
-    def _inherit_populated_from(cls, obj: dict[str, Any]) -> None:
-        """Propagate ``populated_from`` from parent class down to nested CDs.
-
-        Walks each class_derivation's slot_derivations.class_derivations; if
-        a nested CD doesn't set ``populated_from``, it inherits from the
-        outer class's value. Recurses through arbitrarily deep nesting.
-        """
-        for cd in _iter_values_or_list(obj.get("class_derivations")):
-            cls._inherit_pf_in_slots(cd.get("slot_derivations"), cd.get("populated_from"))
-
-    @classmethod
-    def _inherit_pf_in_slots(cls, slots: Any, parent_pf: str | None) -> None:
-        """Recursively inherit populated_from into nested class_derivations."""
-        for sd in _iter_values_or_list(slots):
-            for ncd in _iter_values_or_list(sd.get("class_derivations")):
-                if not ncd.get("populated_from") and parent_pf:
-                    ncd["populated_from"] = parent_pf
-                cls._inherit_pf_in_slots(ncd.get("slot_derivations"), ncd.get("populated_from"))
-
-    @staticmethod
-    def _iter_pv_derivations(obj: dict[str, Any]) -> Iterator[dict[str, Any]]:
-        """Yield each PermissibleValueDerivation dict in ``obj`` for in-place mutation."""
-        eds = obj.get("enum_derivations")
-        if isinstance(eds, dict):
-            ed_iter: Any = eds.values()
-        elif isinstance(eds, list):
-            ed_iter = eds
-        else:
-            return
-        for ed in ed_iter:
-            if not isinstance(ed, dict):
-                continue
-            pvds = ed.get("permissible_value_derivations")
-            if isinstance(pvds, dict):
-                pvd_iter: Any = pvds.values()
-            elif isinstance(pvds, list):
-                pvd_iter = pvds
-            else:
-                continue
-            for pvd in pvd_iter:
-                if isinstance(pvd, dict):
-                    yield pvd
-
-    @classmethod
-    def _coerce_pv_populated_from_to_list(cls, obj: dict[str, Any]) -> None:
-        """Coerce ``populated_from`` to a list on each PV deriv.
-
-        Input shapes handled:
-
-        * Scalar string: wrapped to a one-element list (user convenience that
-          pydantic would otherwise reject for a multivalued field).
-        * Explicit ``None`` or a list whose every element is ``None``
-          (``populated_from:`` with no YAML value, possibly already wrapped to
-          ``[None]`` by ``ReferenceValidator``): the key is removed so pydantic
-          uses the ``default_factory=list`` default — treats "explicitly set to
-          nothing" as "unset". Empty strings and other falsy-but-not-None
-          values are kept (a user may legitimately map to the empty-string PV).
-        * List: left as-is.
-        """
-        for pvd in cls._iter_pv_derivations(obj):
-            if "populated_from" not in pvd:
-                continue
-            pf = pvd["populated_from"]
-            if pf is None or (isinstance(pf, list) and all(x is None for x in pf)):
-                del pvd["populated_from"]
-            elif isinstance(pf, str):
-                pvd["populated_from"] = [pf]
-
-    @classmethod
-    def _migrate_pv_sources_to_populated_from(cls, obj: dict[str, Any]) -> None:
-        """Move deprecated ``sources`` into ``populated_from`` on PV derivs.
-
-        Applied after the pre-normalize scan has already detected and reported
-        any ``sources`` usage and any ``sources`` + ``populated_from`` conflicts.
-        For each PV deriv with ``sources`` set, copies into ``populated_from``
-        (if not already set) and clears the ``sources`` key. A scalar string
-        is wrapped to a one-element list rather than exploded into characters
-        (defends against ``sources: "light_red"`` typos). Post-condition: no
-        PV has ``sources`` set. The runtime can therefore rely on
-        ``populated_from`` as the single source of truth and ignore ``sources``.
-        """
-        for pvd in cls._iter_pv_derivations(obj):
-            srcs = pvd.pop("sources", None)
-            if srcs and not pvd.get("populated_from"):
-                pvd["populated_from"] = [srcs] if isinstance(srcs, str) else list(srcs)
-
-    @staticmethod
-    def _expand_compact_keys(items: list[dict[str, Any]]) -> None:
-        """Expand YAML compact-key dicts in a list in place.
-
-        Converts ``{"Condition": {"populated_from": "x"}}`` →
-        ``{"name": "Condition", "populated_from": "x"}``.
-        Skips items whose sole key is ``"name"`` (already expanded).
-        """
-        for i, item in enumerate(items):
-            if isinstance(item, dict) and len(item) == 1:
-                key, val = next(iter(item.items()))
-                if key != "name" and isinstance(val, dict | type(None)):
-                    expanded = val if val is not None else {}
-                    expanded.setdefault("name", key)
-                    items[i] = expanded
-
-    @staticmethod
-    def _preprocess_class_derivations(obj: dict[str, Any]) -> None:
-        """Pre-process top-level class_derivations before ReferenceValidator normalization.
-
-        Handles two cases:
-        1. Dict format with None values (e.g. ``Entity:`` with no body) — replace
-           with empty dicts so ReferenceValidator.ensure_list doesn't choke.
-        2. List format with compact keys — delegate to ``_expand_compact_keys``.
-        """
-        cd = obj.get("class_derivations")
-        if isinstance(cd, dict):
-            for k, v in cd.items():
-                if v is None:
-                    cd[k] = {}
-        elif isinstance(cd, list):
-            Transformer._expand_compact_keys(cd)
 
     def create_transformer_specification(self, obj: dict[str, Any]) -> None:
         """
@@ -574,7 +179,7 @@ class Transformer(ABC):
         :param path:
         :return:
         """
-        self.spec_messages = self._normalize_spec_dict(obj)
+        self.spec_messages = normalize_spec(obj)
         self.specification = TransformationSpecification(**obj)
 
     def _apply_source_schema_patches(self) -> None:

--- a/src/linkml_map/utils/loaders.py
+++ b/src/linkml_map/utils/loaders.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 
 from linkml_map.datamodel.transformer_model import TransformationSpecification
-from linkml_map.transformer.transformer import Transformer
+from linkml_map.spec_normalizer import normalize_spec
 
 
 def load_specification(path: Path | str) -> TransformationSpecification:
@@ -11,5 +11,5 @@ def load_specification(path: Path | str) -> TransformationSpecification:
         path = str(path)
     with open(path) as f:
         obj = yaml.safe_load(f)
-        Transformer._normalize_spec_dict(obj)
+        normalize_spec(obj)
         return TransformationSpecification(**obj)

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -20,11 +20,10 @@ import ast
 import concurrent.futures
 import json
 import logging
-from dataclasses import dataclass
 from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal, NamedTuple
+from typing import Any, NamedTuple
 
 import jsonschema
 import yaml
@@ -32,7 +31,9 @@ from linkml.generators.jsonschemagen import JsonSchemaGenerator
 from linkml_runtime import SchemaView
 
 from linkml_map.datamodel import TR_SCHEMA
-from linkml_map.transformer.transformer import Transformer
+from linkml_map.spec_normalizer import normalize_spec
+from linkml_map.spec_scan import ValidationMessage, iter_derivation_dicts
+from linkml_map.spec_scan import check_deprecated_fields as check_deprecated_fields  # re-export
 from linkml_map.utils.eval_utils import FUNCTIONS
 from linkml_map.utils.join_utils import resolve_join
 
@@ -60,25 +61,6 @@ _EXPR_SAFE_NAMES = frozenset(
         *FUNCTIONS.keys(),
     }
 )
-
-
-@dataclass
-class ValidationMessage:
-    """A single validation finding with severity and location context.
-
-    ``category`` is an optional tag that downstream consumers can use to
-    group or filter messages. The validator currently emits ``"deprecated"``
-    for warnings about deprecated field usage; other categories may be
-    added in the future.
-    """
-
-    severity: Literal["error", "warning", "info"]
-    path: str
-    message: str
-    category: str | None = None
-
-    def __str__(self) -> str:
-        return f"{self.path}: [{self.severity}] {self.message}"
 
 
 # ---------------------------------------------------------------------------
@@ -166,15 +148,15 @@ def _normalize_and_collect_messages(
 ) -> tuple[dict[str, Any], list[ValidationMessage]]:
     """Normalize and return both the dict and the pre-normalize scan messages.
 
-    Internal helper used by :func:`validate_spec`. Calls the transformer's
-    normalization in silent mode so scan findings are returned as
-    ``ValidationMessage`` records rather than emitted as Python warnings or
-    raised as ``SpecificationError``.
+    Internal helper used by :func:`validate_spec`. Calls
+    :func:`~linkml_map.spec_normalizer.normalize_spec` in silent mode so scan
+    findings are returned as ``ValidationMessage`` records rather than emitted
+    as Python warnings or raised as ``SpecificationError``.
     """
     obj = dict(obj)
     messages: list[ValidationMessage] = []
     try:
-        messages = Transformer._normalize_spec_dict(obj, silent=True) or []
+        messages = normalize_spec(obj, silent=True) or []
     except Exception:
         logger.debug("Normalization failed; falling back to raw dict", exc_info=True)
     for field in _COERCE_FIELDS:
@@ -502,193 +484,6 @@ def _resolve_schemaview(
         return None
 
 
-def _iter_derivation_dicts(raw: Any) -> list[dict[str, Any]]:
-    """Normalize a derivations section (dict or list) to a list of dicts.
-
-    Assumes the SHAPE phase of ``Transformer._normalize_spec_dict`` has
-    already canonicalized compact-key list items, so callers only need to
-    handle dict-keyed and explicit-name list forms here.
-    """
-    if isinstance(raw, list):
-        return [item for item in raw if isinstance(item, dict)]
-    if isinstance(raw, dict):
-        result: list[dict[str, Any]] = []
-        for name, body in raw.items():
-            d = dict(body) if isinstance(body, dict) else {}
-            d.setdefault("name", name)
-            result.append(d)
-        return result
-    return []
-
-
-def check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
-    """Scan a spec dict for deprecated-field usage and ambiguous combinations.
-
-    Runs in the SCAN phase of ``Transformer._normalize_spec_dict`` — after
-    SHAPE (which runs ``ReferenceValidator.normalize()`` and the local
-    compact-key pre-expansion) and before MIGRATE (which flattens
-    ``object_derivations``, inherits ``populated_from``, and rewrites PV
-    ``sources``). So the dict the scan sees is structurally canonical
-    (dict-keyed or explicit-name list, no compact-key items) but the
-    deprecated field values are still as the user wrote them.
-
-    Flags:
-
-    * ``sources`` on ``ClassDerivation`` / ``SlotDerivation`` /
-      ``EnumDerivation`` / ``PermissibleValueDerivation`` — replaced by
-      ``populated_from``. Severity: warning, category: deprecated.
-    * ``derived_from`` on ``SlotDerivation`` — ignored by the runtime
-      and removable. Severity: warning, category: deprecated.
-    * ``object_derivations`` on ``SlotDerivation`` — flattened into
-      ``class_derivations`` at load time. Severity: warning, category:
-      deprecated.
-    * ``populated_from`` **and** ``sources`` both set on the same
-      ``PermissibleValueDerivation`` — ambiguous, the user almost
-      certainly didn't mean both. Severity: error.
-    * ``object_derivations`` **and** ``class_derivations`` both set on
-      the same ``SlotDerivation`` — ambiguous. Severity: error.
-    * ``source_schema`` / ``target_schema`` set to a bare string — the
-      original form, now superseded by the ``SchemaReference`` object
-      form (``{name: ...}``). Coerced at load time. Severity: warning,
-      category: deprecated.
-
-    ``sources`` deprecation findings are collapsed to one message per
-    (deprecation, derivation type) pair to keep output readable on
-    large specs; per-entry messages are emitted for the other categories.
-
-    :param data: A spec dict post-SHAPE, pre-MIGRATE. Derivation sections
-        are dict-keyed or explicit-name list (no compact-key items).
-    :returns: A list of validation messages — warnings for deprecations,
-        errors for ambiguous combinations.
-    """
-    messages: list[ValidationMessage] = []
-    sources_counts: dict[str, list[str]] = {
-        "ClassDerivation": [],
-        "SlotDerivation": [],
-        "EnumDerivation": [],
-        "PermissibleValueDerivation": [],
-    }
-    derived_from_names: list[str] = []
-    object_derivation_names: list[str] = []
-
-    for cd in _iter_derivation_dicts(data.get("class_derivations")):
-        cd_name = cd.get("name", "<unnamed>")
-        if cd.get("sources"):
-            sources_counts["ClassDerivation"].append(cd_name)
-        for sd in _iter_derivation_dicts(cd.get("slot_derivations")):
-            sd_name = sd.get("name", "<unnamed>")
-            if sd.get("sources"):
-                sources_counts["SlotDerivation"].append(sd_name)
-            if sd.get("derived_from"):
-                derived_from_names.append(sd_name)
-            if sd.get("object_derivations"):
-                object_derivation_names.append(sd_name)
-                if sd.get("class_derivations"):
-                    messages.append(
-                        ValidationMessage(
-                            severity="error",
-                            path=f"$.class_derivations[{cd_name}].slot_derivations[{sd_name}]",
-                            message=(
-                                f"SlotDerivation '{sd_name}' sets both 'object_derivations' "
-                                f"and 'class_derivations'. Remove 'object_derivations' and "
-                                f"use 'class_derivations' only."
-                            ),
-                        )
-                    )
-
-    for ed in _iter_derivation_dicts(data.get("enum_derivations")):
-        ed_name = ed.get("name", "<unnamed>")
-        if ed.get("sources"):
-            sources_counts["EnumDerivation"].append(ed_name)
-        for pvd in _iter_derivation_dicts(ed.get("permissible_value_derivations")):
-            pvd_name = pvd.get("name", "<unnamed>")
-            if pvd.get("sources"):
-                sources_counts["PermissibleValueDerivation"].append(pvd_name)
-                if pvd.get("populated_from"):
-                    messages.append(
-                        ValidationMessage(
-                            severity="error",
-                            path=(f"$.enum_derivations[{ed_name}].permissible_value_derivations[{pvd_name}]"),
-                            message=(
-                                f"PermissibleValueDerivation '{pvd_name}' sets both "
-                                f"'populated_from' and 'sources'. These are alternative "
-                                f"spellings of the same field; set only 'populated_from' "
-                                f"(which now accepts a list)."
-                            ),
-                        )
-                    )
-
-    for deriv_type, names in sources_counts.items():
-        if names:
-            preview = ", ".join(names[:5])
-            suffix = f" (and {len(names) - 5} more)" if len(names) > 5 else ""
-            messages.append(
-                ValidationMessage(
-                    severity="warning",
-                    category="deprecated",
-                    path=f"$.{deriv_type}",
-                    message=(
-                        f"{len(names)} {deriv_type}(s) use 'sources', which is deprecated: "
-                        f"{preview}{suffix}. Use 'populated_from' instead. "
-                        f"'sources' will be removed in a future version."
-                    ),
-                )
-            )
-
-    if object_derivation_names:
-        preview = ", ".join(object_derivation_names[:5])
-        suffix = f" (and {len(object_derivation_names) - 5} more)" if len(object_derivation_names) > 5 else ""
-        messages.append(
-            ValidationMessage(
-                severity="warning",
-                category="deprecated",
-                path="$.SlotDerivation",
-                message=(
-                    f"{len(object_derivation_names)} SlotDerivation(s) use 'object_derivations', "
-                    f"which is deprecated and flattened into 'class_derivations' at load time: "
-                    f"{preview}{suffix}. Use list-based 'class_derivations' instead. "
-                    f"'object_derivations' will be removed in a future version. "
-                    f"See https://github.com/linkml/linkml-map/issues/112"
-                ),
-            )
-        )
-
-    if derived_from_names:
-        preview = ", ".join(derived_from_names[:5])
-        suffix = f" (and {len(derived_from_names) - 5} more)" if len(derived_from_names) > 5 else ""
-        messages.append(
-            ValidationMessage(
-                severity="warning",
-                category="deprecated",
-                path="$.SlotDerivation",
-                message=(
-                    f"{len(derived_from_names)} SlotDerivation(s) use 'derived_from', "
-                    f"which is deprecated and ignored by the runtime: "
-                    f"{preview}{suffix}. This field can be removed — source slot "
-                    f"dependencies are derivable from 'expr'. 'derived_from' will "
-                    f"be removed in a future version."
-                ),
-            )
-        )
-
-    for schema_field in ("source_schema", "target_schema"):
-        if isinstance(data.get(schema_field), str):
-            messages.append(
-                ValidationMessage(
-                    severity="warning",
-                    category="deprecated",
-                    path=f"$.{schema_field}",
-                    message=(
-                        f"'{schema_field}' is set to a bare string, which is deprecated. "
-                        f"Use the SchemaReference object form '{schema_field}: {{name: ...}}'. "
-                        f"The string form will be removed in a future version."
-                    ),
-                )
-            )
-
-    return messages
-
-
 def validate_spec_semantics(
     data: dict[str, Any],
     *,
@@ -749,7 +544,7 @@ def validate_spec_semantics(
     target_all_classes = set(target_sv.all_classes()) if target_sv is not None else set()
 
     # Validate class_derivations (recurses into nested CDs internally)
-    for cd in _iter_derivation_dicts(data.get("class_derivations", [])):
+    for cd in iter_derivation_dicts(data.get("class_derivations", [])):
         _validate_class_derivation(
             cd,
             source_sv,
@@ -762,7 +557,7 @@ def validate_spec_semantics(
         )
 
     # Validate enum_derivations
-    for ed in _iter_derivation_dicts(data.get("enum_derivations", [])):
+    for ed in iter_derivation_dicts(data.get("enum_derivations", [])):
         _validate_enum_derivation(ed, source_sv, target_sv, messages)
 
     return messages
@@ -777,7 +572,7 @@ def _collect_class_derivation_pool(data: dict[str, Any]) -> set[str]:
     :meth:`~linkml_map.transformer.transformer.Transformer._find_class_derivation_by_name`
     which raises ``KeyError`` for anything not at the top level.
     """
-    return {cd.get("name") for cd in _iter_derivation_dicts(data.get("class_derivations", [])) if cd.get("name")}
+    return {cd.get("name") for cd in iter_derivation_dicts(data.get("class_derivations", [])) if cd.get("name")}
 
 
 def _slot_is_string_typed(sv: SchemaView, range_name: str | None) -> bool:
@@ -907,7 +702,7 @@ def _validate_class_derivation(
         }
 
     # Validate slot_derivations (may be list or dict after normalization)
-    slot_derivation_dicts = _iter_derivation_dicts(cd.get("slot_derivations", []))
+    slot_derivation_dicts = iter_derivation_dicts(cd.get("slot_derivations", []))
 
     # Build alias -> slot-set map for cross-table expression reference checks.
     # Covers both explicit `joins:` aliases and the nested-CD populated_from
@@ -930,7 +725,7 @@ def _validate_class_derivation(
         )
 
         # Recurse into nested class_derivations declared on this slot.
-        for nested_cd in _iter_derivation_dicts(sd.get("class_derivations", [])):
+        for nested_cd in iter_derivation_dicts(sd.get("class_derivations", [])):
             _validate_class_derivation(
                 nested_cd,
                 source_sv,
@@ -1010,7 +805,7 @@ def _build_joined_class_map(
     parent_source = cd.get("populated_from") or cd.get("name")
     if source_sv is not None and parent_source:
         for sd in slot_derivation_dicts:
-            for nested in _iter_derivation_dicts(sd.get("class_derivations", [])):
+            for nested in iter_derivation_dicts(sd.get("class_derivations", [])):
                 nested_source = nested.get("populated_from")
                 if nested_source and nested_source != parent_source and nested_source not in result:
                     if nested_source in source_all_classes:

--- a/tests/test_spec_normalizer.py
+++ b/tests/test_spec_normalizer.py
@@ -1,0 +1,86 @@
+"""Tests for the standalone spec normalizer and its scan phase."""
+
+import subprocess
+import sys
+import warnings
+
+import pytest
+
+from linkml_map.spec_normalizer import normalize_spec
+from linkml_map.transformer.errors import SpecificationError
+
+
+def test_normalizer_does_not_import_the_validator() -> None:
+    """The normalizer must not drag the validator in — that was the import cycle.
+
+    Run in a fresh interpreter so an already-imported validator from another
+    test module can't mask a regression.
+    """
+    code = "import sys, linkml_map.spec_normalizer; print('linkml_map.validator' in sys.modules)"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "False"
+
+
+def test_normalize_spec_expands_compact_keys_and_injects_names() -> None:
+    """Compact-key list entries become explicit-name dicts (the SHAPE phase)."""
+    spec = {
+        "id": "https://example.org/test",
+        "name": "test",
+        "class_derivations": [{"Person": {"populated_from": "Individual"}}],
+    }
+    normalize_spec(spec)
+    (cd,) = spec["class_derivations"]
+    assert cd["name"] == "Person"
+    assert cd["populated_from"] == "Individual"
+
+
+def test_normalize_spec_migrates_pv_sources_and_reports_it() -> None:
+    """MIGRATE clears PV ``sources`` into ``populated_from``; SCAN reports the deprecation."""
+    spec = {
+        "id": "https://example.org/test",
+        "name": "test",
+        "enum_derivations": {
+            "ColorEnum": {
+                "permissible_value_derivations": {"red": {"sources": "RED"}},
+            }
+        },
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        messages = normalize_spec(spec)
+
+    pvd = spec["enum_derivations"]["ColorEnum"]["permissible_value_derivations"]["red"]
+    assert "sources" not in pvd
+    assert pvd["populated_from"] == ["RED"]
+    assert any(m.category == "deprecated" for m in messages)
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_normalize_spec_silent_returns_errors_instead_of_raising() -> None:
+    """``silent=True`` is the validator's path: findings come back as messages."""
+    spec = {
+        "id": "https://example.org/test",
+        "name": "test",
+        "enum_derivations": {
+            "ColorEnum": {
+                "permissible_value_derivations": {"red": {"sources": "RED", "populated_from": ["CRIMSON"]}},
+            }
+        },
+    }
+    messages = normalize_spec(spec, silent=True)
+    assert [m for m in messages if m.severity == "error"]
+
+
+def test_normalize_spec_raises_on_conflicting_fields() -> None:
+    """Without ``silent``, a scan error aborts the load."""
+    spec = {
+        "id": "https://example.org/test",
+        "name": "test",
+        "enum_derivations": {
+            "ColorEnum": {
+                "permissible_value_derivations": {"red": {"sources": "RED", "populated_from": ["CRIMSON"]}},
+            }
+        },
+    }
+    with pytest.raises(SpecificationError, match="populated_from"):
+        normalize_spec(spec)

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -26,9 +26,9 @@ from linkml_map.datamodel.transformer_model import (
     SlotDerivation,
     TransformationSpecification,
 )
+from linkml_map.spec_normalizer import normalize_spec
 from linkml_map.transformer.errors import TransformationError
 from linkml_map.transformer.object_transformer import ObjectTransformer
-from linkml_map.transformer.transformer import Transformer
 from linkml_map.utils.dynamic_object import dynamic_object
 from tests import (
     DENORM_SCHEMA,
@@ -655,7 +655,7 @@ def test_normalize_defaults_range_for_literal_value() -> None:
             }
         }
     }
-    Transformer._normalize_spec_dict(spec)
+    normalize_spec(spec)
     class_deriv = spec["class_derivations"][0]
     slot = class_deriv["slot_derivations"]["my_slot"]
     assert slot["range"] == "string"
@@ -711,7 +711,7 @@ def test_self_transform() -> None:
     tr.source_schemaview = SchemaView(str(TR_SCHEMA))
     tr.load_transformer_specification(TR_TO_MAPPING_TABLES)
     source_object = yaml.safe_load(open(str(PERSONINFO_TR)))
-    Transformer._normalize_spec_dict(source_object)
+    normalize_spec(source_object)
     derived = tr.map_object(source_object)
     print(derived)
     print(yaml.dump(derived))

--- a/tests/test_upstream_canaries.py
+++ b/tests/test_upstream_canaries.py
@@ -17,7 +17,7 @@ import pytest
         "list input to inlined-dict fields as {None: ...}. The proposed upstream "
         "fix hoists unambiguous single-key items (and errors on degenerate cases). "
         "Our test case is unambiguous so it will hoist. When this passes, remove "
-        "the PV-level branch from Transformer._pre_shape_expand_compact_keys."
+        "the PV-level branch from spec_normalizer._pre_shape_expand_compact_keys."
     ),
 )
 def test_reference_validator_normalizes_compact_key_pv_list():


### PR DESCRIPTION
The load-time spec normalization was ~374 lines of `@classmethod`/`@staticmethod` on the `Transformer` ABC that never touched `self`. Four modules — `session.py`, `cli.py`, `utils/loaders.py`, `validator.py` — imported the base class solely to call `Transformer._normalize_spec_dict` on a dict.

Those functions now live in `spec_normalizer.py` as module-level functions, entry point `normalize_spec(obj, *, silent=False)`. The SCAN phase they depend on (`check_deprecated_fields`, `ValidationMessage`, `iter_derivation_dicts`) moves to `spec_scan.py` underneath.

Moving the normalizer alone would have relocated the cycle rather than removed it — the validator needs the normalizer, and the normalizer needs `check_deprecated_fields`. Putting the scan below both makes the dependencies one-way (`validator → spec_normalizer → spec_scan`), so the function-body `from linkml_map.validator import check_deprecated_fields` that papered over the old cycle is gone. A test asserts the direction stays one-way.

The other payoff is testability: normalization can now be exercised without constructing a transformer, which `tests/test_spec_normalizer.py` does.

One thing this does **not** do, despite the issue claiming it: reduce what `validator.py` pulls in at import time. `linkml_map/__init__.py` imports `ObjectTransformer` eagerly, so `curies` and `ReferenceValidator` load regardless. The cycle argument holds; the dependency-weight one doesn't.

Naming: the entry point is `normalize_spec` rather than `normalize_spec_dict`, because `validator.normalize_spec_dict` already exists with a different signature and return type. `iter_derivation_dicts` loses its underscore since the validator uses it in six places. `check_deprecated_fields` is re-exported from `validator` so existing imports keep working.

Pure move otherwise — no behavior change, full suite green.

Closes #303