### PR TITLE
Extract the pivot and unit-conversion blocks out of object_transformer

### DIFF
--- a/src/linkml_map/functions/unit_conversion.py
+++ b/src/linkml_map/functions/unit_conversion.py
@@ -7,12 +7,19 @@ For UCUM, the ucumvert library is used to convert UCUM units to pint units,
 see `<https://github.com/dalito/ucumvert>`_.
 """
 
+import logging
 from enum import Enum
 from functools import lru_cache
+from typing import Any
 
 import lark
 import pint
+from linkml_runtime import SchemaView
 from ucumvert import PintUcumRegistry
+
+from linkml_map.datamodel.transformer_model import SlotDerivation
+
+logger = logging.getLogger(__name__)
 
 
 class UnitSystem(str, Enum):
@@ -160,3 +167,111 @@ def normalize_unit(unit: str, system: UnitSystem | None = None) -> str:
     except lark.exceptions.UnexpectedCharacters as err:
         msg = f"Cannot parse unit: {unit}"
         raise UndefinedUnitError(msg) from err
+
+
+def perform_unit_conversion(
+    slot_derivation: SlotDerivation,
+    source_obj: dict[str, Any],
+    sv: SchemaView,
+    source_type: str,
+) -> float | dict | None:
+    """Convert a slot's value between units, per its ``unit_conversion`` config.
+
+    Takes the source row, schemaview and source type explicitly rather than a
+    ``DerivationContext``: that type lives in ``object_transformer``, which imports
+    this module, so depending on it here would be circular.
+
+    :param slot_derivation: the derivation carrying the ``unit_conversion`` block
+    :param source_obj: the source row
+    :param sv: source schema view, for resolving the slot's declared unit
+    :param source_type: source class name
+    :return: the converted magnitude, a structured value, or None
+    :rtype: float | dict | None
+    """
+    uc = slot_derivation.unit_conversion
+    curr_v = source_obj.get(slot_derivation.populated_from, None)
+
+    if curr_v is None:
+        logger.debug(f"No value found for slot '{slot_derivation.populated_from}'; skipping conversion")
+        return None
+
+    slot = sv.induced_slot(slot_derivation.populated_from, source_type)
+    schema_unit = None
+    from_unit = None
+    system = UnitSystem.UCUM
+
+    if slot.unit:
+        if slot.unit.ucum_code:
+            schema_unit = slot.unit.ucum_code
+        elif slot.unit.iec61360code:
+            schema_unit = slot.unit.iec61360code
+            system = UnitSystem.IEC61360
+        elif slot.unit.symbol:
+            schema_unit = slot.unit.symbol
+            system = None
+        elif slot.unit.abbreviation:
+            schema_unit = slot.unit.abbreviation
+            system = None
+        elif slot.unit.descriptive_name:
+            schema_unit = slot.unit.descriptive_name
+            system = None
+        else:
+            raise NotImplementedError(f"Cannot determine unit system for slot '{slot.name}' — all unit fields are None")
+
+    spec_unit = uc.source_unit if uc.source_unit else None
+
+    if schema_unit and spec_unit:
+        if schema_unit != spec_unit:
+            raise ValueError(
+                f"Mismatch in source units for slot '{slot_derivation.populated_from}': "
+                f"schema unit '{schema_unit}' vs. transformation spec '{spec_unit}'"
+            )
+        from_unit = schema_unit
+    elif schema_unit:
+        from_unit = schema_unit
+    elif spec_unit:
+        from_unit = spec_unit
+    else:
+        if uc.source_unit_slot:
+            from_unit = None
+        else:
+            slot_name = slot_derivation.populated_from
+            raise ValueError(f"No source unit provided in schema or transformation spec for slot '{slot_name}'")
+
+    if uc.source_unit_slot:
+        # Structured input, e.g., {"value": 120, "unit": "cm"}
+        from_unit_val = curr_v.get(uc.source_unit_slot)
+        if from_unit_val:
+            if from_unit and from_unit_val != from_unit:
+                slot_name = slot_derivation.populated_from
+                raise ValueError(
+                    f"Value unit '{from_unit_val}' does not match expected '{from_unit}' for slot '{slot_name}'"
+                )
+            from_unit = from_unit_val
+        else:
+            raise ValueError(f"Missing unit in structured value for slot '{slot_derivation.populated_from}': {curr_v}")
+
+        magnitude = curr_v.get(uc.source_magnitude_slot)
+        if magnitude is None:
+            raise ValueError(
+                f"Missing magnitude in structured value for slot '{slot_derivation.populated_from}': {curr_v}"
+            )
+    else:
+        magnitude = curr_v
+
+    try:
+        magnitude = float(magnitude)
+    except (TypeError, ValueError):
+        if uc.none_if_non_numeric:
+            return None
+        raise
+
+    to_unit = uc.target_unit or from_unit
+    if from_unit == to_unit:
+        result = magnitude
+    else:
+        result = convert_units(magnitude, from_unit=from_unit, to_unit=to_unit, system=system)
+
+    if uc.target_magnitude_slot:
+        return {uc.target_magnitude_slot: result, uc.target_unit_slot: to_unit}
+    return result

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -395,9 +395,7 @@ class ObjectTransformer(Transformer):
 
         # Handle class-level pivot operations (UNMELT from EAV to wide format)
         if class_deriv.pivot_operation:
-            return perform_pivot_operation(
-                class_deriv.pivot_operation, source_obj, class_deriv, sv, source_type, self.target_schemaview
-            )
+            return perform_pivot_operation(class_deriv.pivot_operation, source_obj, self.target_schemaview)
 
         context = DerivationContext(
             source_obj=source_obj,
@@ -478,9 +476,7 @@ class ObjectTransformer(Transformer):
             v = perform_unit_conversion(slot_derivation, context.source_obj, context.sv, context.source_type)
         elif slot_derivation.pivot_operation:
             # MELT operation: wide format to EAV/long format
-            v = perform_melt(
-                slot_derivation.pivot_operation, context.source_obj, slot_derivation, self.target_schemaview
-            )
+            v = perform_melt(slot_derivation.pivot_operation, context.source_obj, self.target_schemaview)
         elif slot_derivation.expr:
             v = self._eval_expr(slot_derivation.expr, bindings, functions=expr_functions)
         elif slot_derivation.populated_from:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -21,13 +21,12 @@ from simpleeval import InvalidExpression
 from linkml_map.datamodel.transformer_model import (
     ClassDerivation,
     CollectionType,
-    PivotDirectionType,
-    PivotOperation,
     SerializationSyntaxType,
     SlotDerivation,
 )
-from linkml_map.functions.unit_conversion import UnitSystem, convert_units
+from linkml_map.functions.unit_conversion import perform_unit_conversion
 from linkml_map.transformer.errors import TransformationError
+from linkml_map.transformer.pivot import perform_melt, perform_pivot_operation
 from linkml_map.transformer.transformer import OBJECT_TYPE, Transformer
 from linkml_map.utils.dynamic_object import DynObj, dynamic_object
 from linkml_map.utils.eval_utils import _uuid5, eval_expr_with_mapping
@@ -396,7 +395,9 @@ class ObjectTransformer(Transformer):
 
         # Handle class-level pivot operations (UNMELT from EAV to wide format)
         if class_deriv.pivot_operation:
-            return self._perform_pivot_operation(class_deriv.pivot_operation, source_obj, class_deriv, sv, source_type)
+            return perform_pivot_operation(
+                class_deriv.pivot_operation, source_obj, class_deriv, sv, source_type, self.target_schemaview
+            )
 
         context = DerivationContext(
             source_obj=source_obj,
@@ -474,10 +475,12 @@ class ObjectTransformer(Transformer):
         if slot_derivation.value is not None:
             v = slot_derivation.value
         elif slot_derivation.unit_conversion:
-            v = self._perform_unit_conversion(slot_derivation, context)
+            v = perform_unit_conversion(slot_derivation, context.source_obj, context.sv, context.source_type)
         elif slot_derivation.pivot_operation:
             # MELT operation: wide format to EAV/long format
-            v = self._perform_melt(slot_derivation.pivot_operation, context.source_obj, slot_derivation)
+            v = perform_melt(
+                slot_derivation.pivot_operation, context.source_obj, slot_derivation, self.target_schemaview
+            )
         elif slot_derivation.expr:
             v = self._eval_expr(slot_derivation.expr, bindings, functions=expr_functions)
         elif slot_derivation.populated_from:
@@ -1117,104 +1120,6 @@ class ObjectTransformer(Transformer):
         all_enums = sv.all_enums()
         return [ao.range for ao in slot.any_of if ao.range in all_enums]
 
-    def _perform_unit_conversion(
-        self,
-        slot_derivation: SlotDerivation,
-        context: DerivationContext,
-    ) -> float | dict | None:
-        """Perform unit conversion for a slot derivation."""
-        uc = slot_derivation.unit_conversion
-        curr_v = context.source_obj.get(slot_derivation.populated_from, None)
-
-        if curr_v is None:
-            logger.debug(f"No value found for slot '{slot_derivation.populated_from}'; skipping conversion")
-            return None
-
-        slot = context.sv.induced_slot(slot_derivation.populated_from, context.source_type)
-        schema_unit = None
-        from_unit = None
-        system = UnitSystem.UCUM
-
-        if slot.unit:
-            if slot.unit.ucum_code:
-                schema_unit = slot.unit.ucum_code
-            elif slot.unit.iec61360code:
-                schema_unit = slot.unit.iec61360code
-                system = UnitSystem.IEC61360
-            elif slot.unit.symbol:
-                schema_unit = slot.unit.symbol
-                system = None
-            elif slot.unit.abbreviation:
-                schema_unit = slot.unit.abbreviation
-                system = None
-            elif slot.unit.descriptive_name:
-                schema_unit = slot.unit.descriptive_name
-                system = None
-            else:
-                raise NotImplementedError(
-                    f"Cannot determine unit system for slot '{slot.name}' — all unit fields are None"
-                )
-
-        spec_unit = uc.source_unit if uc.source_unit else None
-
-        if schema_unit and spec_unit:
-            if schema_unit != spec_unit:
-                raise ValueError(
-                    f"Mismatch in source units for slot '{slot_derivation.populated_from}': "
-                    f"schema unit '{schema_unit}' vs. transformation spec '{spec_unit}'"
-                )
-            from_unit = schema_unit
-        elif schema_unit:
-            from_unit = schema_unit
-        elif spec_unit:
-            from_unit = spec_unit
-        else:
-            if uc.source_unit_slot:
-                from_unit = None
-            else:
-                slot_name = slot_derivation.populated_from
-                raise ValueError(f"No source unit provided in schema or transformation spec for slot '{slot_name}'")
-
-        if uc.source_unit_slot:
-            # Structured input, e.g., {"value": 120, "unit": "cm"}
-            from_unit_val = curr_v.get(uc.source_unit_slot)
-            if from_unit_val:
-                if from_unit and from_unit_val != from_unit:
-                    slot_name = slot_derivation.populated_from
-                    raise ValueError(
-                        f"Value unit '{from_unit_val}' does not match expected '{from_unit}' for slot '{slot_name}'"
-                    )
-                from_unit = from_unit_val
-            else:
-                raise ValueError(
-                    f"Missing unit in structured value for slot '{slot_derivation.populated_from}': {curr_v}"
-                )
-
-            magnitude = curr_v.get(uc.source_magnitude_slot)
-            if magnitude is None:
-                raise ValueError(
-                    f"Missing magnitude in structured value for slot '{slot_derivation.populated_from}': {curr_v}"
-                )
-        else:
-            magnitude = curr_v
-
-        try:
-            magnitude = float(magnitude)
-        except (TypeError, ValueError):
-            if uc.none_if_non_numeric:
-                return None
-            raise
-
-        to_unit = uc.target_unit or from_unit
-        if from_unit == to_unit:
-            result = magnitude
-        else:
-            result = convert_units(magnitude, from_unit=from_unit, to_unit=to_unit, system=system)
-
-        if uc.target_magnitude_slot:
-            return {uc.target_magnitude_slot: result, uc.target_unit_slot: to_unit}
-        return result
-
     def _multivalued_to_singlevalued(self, vs: list[Any], slot_derivation: SlotDerivation) -> Any:
         if slot_derivation.stringification:
             stringification = slot_derivation.stringification
@@ -1339,220 +1244,3 @@ class ObjectTransformer(Transformer):
             if enum_deriv.mirror_source:
                 return str(source_value)
         return None
-
-    def _perform_pivot_operation(
-        self,
-        pivot_op: PivotOperation,
-        source_obj: DICT_OBJ,
-        class_deriv: ClassDerivation,
-        sv: SchemaView,
-        source_type: str,
-    ) -> DICT_OBJ | list[DICT_OBJ]:
-        """
-        Perform a pivot (MELT or UNMELT) operation.
-
-        :param pivot_op: The pivot operation configuration
-        :param source_obj: The source object to transform
-        :param class_deriv: The class derivation spec
-        :param sv: Source schema view
-        :param source_type: Source type name
-        :return: Transformed object(s)
-        """
-        if pivot_op.direction == PivotDirectionType.UNMELT:
-            return self._perform_unmelt(pivot_op, source_obj, class_deriv, sv, source_type)
-        elif pivot_op.direction == PivotDirectionType.MELT:
-            return self._perform_melt(pivot_op, source_obj, class_deriv)
-        else:
-            msg = f"Unknown pivot direction: {pivot_op.direction}"
-            raise ValueError(msg)
-
-    def _perform_unmelt(
-        self,
-        pivot_op: PivotOperation,
-        source_obj: DICT_OBJ,
-        class_deriv: ClassDerivation,
-        sv: SchemaView,
-        source_type: str,
-    ) -> DICT_OBJ:
-        """
-        Transform EAV/long format to wide format.
-
-        Handles both single record and collection-based unmelt:
-        - Single record: {att: 'len', val: 1.0} -> {len: 1.0}
-        - Collection: [{att: 'h', val: 1.8}, {att: 'w', val: 75}] -> {h: 1.8, w: 75}
-
-        :param pivot_op: The pivot operation configuration
-        :param source_obj: The source object (may contain EAV records)
-        :param class_deriv: The class derivation spec
-        :param sv: Source schema view
-        :param source_type: Source type name
-        :return: Wide-format object
-        """
-        variable_slot = pivot_op.variable_slot or "variable"
-        value_slot = pivot_op.value_slot or "value"
-        unit_slot = pivot_op.unit_slot
-        template = pivot_op.slot_name_template or "{variable}"
-
-        # Check if source_obj itself is an EAV record (has variable and value slots)
-        if variable_slot in source_obj and value_slot in source_obj:
-            return self._unmelt_single_record(pivot_op, source_obj, variable_slot, value_slot, unit_slot, template)
-
-        # Otherwise, look for a collection of EAV records in the source
-        # Try to find a multivalued slot containing EAV records
-        for slot_name, slot_value in source_obj.items():
-            if isinstance(slot_value, list) and len(slot_value) > 0:
-                first_item = slot_value[0]
-                if isinstance(first_item, dict) and variable_slot in first_item:
-                    return self._unmelt_collection(pivot_op, slot_value)
-
-        # Fallback: treat source_obj as a single EAV record
-        return self._unmelt_single_record(pivot_op, source_obj, variable_slot, value_slot, unit_slot, template)
-
-    def _unmelt_single_record(
-        self,
-        pivot_op: PivotOperation,
-        record: DICT_OBJ,
-        variable_slot: str,
-        value_slot: str,
-        unit_slot: str | None,
-        template: str,
-    ) -> DICT_OBJ:
-        """
-        Unmelt a single EAV record into slot assignment(s).
-
-        Example:
-            Input:  {att: 'len', val: 1.0, unit: 'm'}
-            Output: {len_m: 1.0}
-        """
-        result = {}
-
-        # Copy ID slots (non-pivoted attributes)
-        if pivot_op.id_slots:
-            for id_slot in pivot_op.id_slots:
-                if id_slot in record:
-                    result[id_slot] = record[id_slot]
-
-        # Get variable and value
-        variable = record.get(variable_slot)
-        value = record.get(value_slot)
-
-        if variable is None:
-            logger.warning(f"No variable found in slot '{variable_slot}'")
-            return result
-
-        # Generate target slot name
-        if unit_slot and unit_slot in record:
-            unit = record[unit_slot]
-            target_slot_name = template.format(variable=variable, unit=unit)
-        else:
-            target_slot_name = template.format(variable=variable, unit="")
-
-        # Validate against target schema if unmelt_to_class specified
-        if pivot_op.unmelt_to_class and self.target_schemaview:
-            valid_slots = [s.name for s in self.target_schemaview.class_induced_slots(pivot_op.unmelt_to_class)]
-            if pivot_op.unmelt_to_slots:
-                valid_slots = [s for s in valid_slots if s in pivot_op.unmelt_to_slots]
-
-            if target_slot_name not in valid_slots:
-                logger.warning(
-                    f"Generated slot name '{target_slot_name}' not in valid slots for "
-                    f"class '{pivot_op.unmelt_to_class}'"
-                )
-
-        result[target_slot_name] = value
-        return result
-
-    def _unmelt_collection(
-        self,
-        pivot_op: PivotOperation,
-        records: list[DICT_OBJ],
-    ) -> DICT_OBJ:
-        """
-        Unmelt a collection of EAV records into a single wide object.
-
-        Example:
-            Input:  [{att: 'height', val: 1.8}, {att: 'weight', val: 75.0}]
-            Output: {height: 1.8, weight: 75.0}
-        """
-        result = {}
-        variable_slot = pivot_op.variable_slot or "variable"
-        value_slot = pivot_op.value_slot or "value"
-        unit_slot = pivot_op.unit_slot
-        template = pivot_op.slot_name_template or "{variable}"
-
-        for record in records:
-            variable = record.get(variable_slot)
-            value = record.get(value_slot)
-
-            if variable is None:
-                continue
-
-            if unit_slot and unit_slot in record:
-                unit = record[unit_slot]
-                target_slot = template.format(variable=variable, unit=unit)
-            else:
-                target_slot = template.format(variable=variable, unit="")
-
-            if target_slot in result:
-                logger.warning(f"Duplicate variable '{variable}' in unmelt; last value wins")
-
-            result[target_slot] = value
-
-        # Copy ID slots from the first record (assuming they're the same across all)
-        if pivot_op.id_slots and records:
-            for id_slot in pivot_op.id_slots:
-                if id_slot in records[0]:
-                    result[id_slot] = records[0][id_slot]
-
-        return result
-
-    def _perform_melt(
-        self,
-        pivot_op: PivotOperation,
-        source_obj: DICT_OBJ,
-        slot_derivation: SlotDerivation | None = None,
-    ) -> list[DICT_OBJ]:
-        """
-        Transform wide format to EAV/long format.
-
-        Example:
-            Input:  {height: 1.8, weight: 75.0}
-            Output: [{variable: 'height', value: 1.8}, {variable: 'weight', value: 75.0}]
-
-        :param pivot_op: The pivot operation configuration
-        :param source_obj: The source object in wide format
-        :param slot_derivation: Optional slot derivation (for context)
-        :return: List of EAV records
-        """
-        variable_slot = pivot_op.variable_slot or "variable"
-        value_slot = pivot_op.value_slot or "value"
-
-        # Determine which slots to melt
-        if pivot_op.source_slots:
-            slots_to_melt = list(pivot_op.source_slots)
-        elif pivot_op.unmelt_to_class and self.target_schemaview:
-            # Infer from target class
-            slots_to_melt = [s.name for s in self.target_schemaview.class_induced_slots(pivot_op.unmelt_to_class)]
-        else:
-            # Melt all non-ID slots
-            id_slots = set(pivot_op.id_slots or [])
-            slots_to_melt = [k for k in source_obj.keys() if k not in id_slots]
-
-        results = []
-        base_record = {}
-
-        # Copy ID slots to base record
-        if pivot_op.id_slots:
-            for id_slot in pivot_op.id_slots:
-                if id_slot in source_obj:
-                    base_record[id_slot] = source_obj[id_slot]
-
-        # Create one record per melted slot
-        for slot_name in slots_to_melt:
-            if slot_name in source_obj and source_obj[slot_name] is not None:
-                record = base_record.copy()
-                record[variable_slot] = slot_name
-                record[value_slot] = source_obj[slot_name]
-                results.append(record)
-
-        return results

--- a/src/linkml_map/transformer/pivot.py
+++ b/src/linkml_map/transformer/pivot.py
@@ -1,8 +1,8 @@
 """Pivot (MELT / UNMELT) operations for EAV-shaped data.
 
 Extracted from ``ObjectTransformer`` (issue #304). These never touched instance
-state beyond ``target_schemaview``, which the two functions that need it now take
-explicitly, so they are plain module functions rather than methods.
+state beyond ``target_schemaview``, which is now a required ``target_sv``
+parameter, so they are plain module functions rather than methods.
 
 ``perform_pivot_operation`` and ``perform_melt`` are the entry points the
 transformer calls; the rest are internal steps.

--- a/src/linkml_map/transformer/pivot.py
+++ b/src/linkml_map/transformer/pivot.py
@@ -1,8 +1,10 @@
 """Pivot (MELT / UNMELT) operations for EAV-shaped data.
 
 Extracted from ``ObjectTransformer`` (issue #304). These never touched instance
-state beyond ``target_schemaview``, which is now a required ``target_sv``
-parameter, so they are plain module functions rather than methods.
+state beyond ``target_schemaview``, which every function now takes as an explicit
+``target_sv`` argument. It has no default — callers must pass it — though the
+value itself may be ``None``. So they are plain module functions rather than
+methods.
 
 ``perform_pivot_operation`` and ``perform_melt`` are the entry points the
 transformer calls; the rest are internal steps.

--- a/src/linkml_map/transformer/pivot.py
+++ b/src/linkml_map/transformer/pivot.py
@@ -14,10 +14,8 @@ from typing import Any
 from linkml_runtime import SchemaView
 
 from linkml_map.datamodel.transformer_model import (
-    ClassDerivation,
     PivotDirectionType,
     PivotOperation,
-    SlotDerivation,
 )
 
 logger = logging.getLogger(__name__)
@@ -28,25 +26,20 @@ DICT_OBJ = dict[str, Any]
 def perform_pivot_operation(
     pivot_op: PivotOperation,
     source_obj: DICT_OBJ,
-    class_deriv: ClassDerivation,
-    sv: SchemaView,
-    source_type: str,
-    target_sv: SchemaView | None = None,
+    target_sv: SchemaView | None,
 ) -> DICT_OBJ | list[DICT_OBJ]:
     """
     Perform a pivot (MELT or UNMELT) operation.
 
     :param pivot_op: The pivot operation configuration
     :param source_obj: The source object to transform
-    :param class_deriv: The class derivation spec
-    :param sv: Source schema view
-    :param source_type: Source type name
+    :param target_sv: Target schema view, used to resolve ``unmelt_to_class``
     :return: Transformed object(s)
     """
     if pivot_op.direction == PivotDirectionType.UNMELT:
-        return _perform_unmelt(pivot_op, source_obj, class_deriv, sv, source_type, target_sv)
+        return _perform_unmelt(pivot_op, source_obj, target_sv)
     elif pivot_op.direction == PivotDirectionType.MELT:
-        return perform_melt(pivot_op, source_obj, class_deriv, target_sv)
+        return perform_melt(pivot_op, source_obj, target_sv)
     else:
         msg = f"Unknown pivot direction: {pivot_op.direction}"
         raise ValueError(msg)
@@ -55,10 +48,7 @@ def perform_pivot_operation(
 def _perform_unmelt(
     pivot_op: PivotOperation,
     source_obj: DICT_OBJ,
-    class_deriv: ClassDerivation,
-    sv: SchemaView,
-    source_type: str,
-    target_sv: SchemaView | None = None,
+    target_sv: SchemaView | None,
 ) -> DICT_OBJ:
     """
     Transform EAV/long format to wide format.
@@ -69,9 +59,7 @@ def _perform_unmelt(
 
     :param pivot_op: The pivot operation configuration
     :param source_obj: The source object (may contain EAV records)
-    :param class_deriv: The class derivation spec
-    :param sv: Source schema view
-    :param source_type: Source type name
+    :param target_sv: Target schema view, used to resolve ``unmelt_to_class``
     :return: Wide-format object
     """
     variable_slot = pivot_op.variable_slot or "variable"
@@ -85,7 +73,7 @@ def _perform_unmelt(
 
     # Otherwise, look for a collection of EAV records in the source
     # Try to find a multivalued slot containing EAV records
-    for slot_name, slot_value in source_obj.items():
+    for slot_value in source_obj.values():
         if isinstance(slot_value, list) and len(slot_value) > 0:
             first_item = slot_value[0]
             if isinstance(first_item, dict) and variable_slot in first_item:
@@ -102,7 +90,7 @@ def _unmelt_single_record(
     value_slot: str,
     unit_slot: str | None,
     template: str,
-    target_sv: SchemaView | None = None,
+    target_sv: SchemaView | None,
 ) -> DICT_OBJ:
     """
     Unmelt a single EAV record into slot assignment(s).
@@ -196,8 +184,7 @@ def _unmelt_collection(
 def perform_melt(
     pivot_op: PivotOperation,
     source_obj: DICT_OBJ,
-    slot_derivation: SlotDerivation | None = None,
-    target_sv: SchemaView | None = None,
+    target_sv: SchemaView | None,
 ) -> list[DICT_OBJ]:
     """
     Transform wide format to EAV/long format.
@@ -208,7 +195,7 @@ def perform_melt(
 
     :param pivot_op: The pivot operation configuration
     :param source_obj: The source object in wide format
-    :param slot_derivation: Optional slot derivation (for context)
+    :param target_sv: Target schema view, used to resolve ``unmelt_to_class``
     :return: List of EAV records
     """
     variable_slot = pivot_op.variable_slot or "variable"

--- a/src/linkml_map/transformer/pivot.py
+++ b/src/linkml_map/transformer/pivot.py
@@ -1,0 +1,245 @@
+"""Pivot (MELT / UNMELT) operations for EAV-shaped data.
+
+Extracted from ``ObjectTransformer`` (issue #304). These never touched instance
+state beyond ``target_schemaview``, which the two functions that need it now take
+explicitly, so they are plain module functions rather than methods.
+
+``perform_pivot_operation`` and ``perform_melt`` are the entry points the
+transformer calls; the rest are internal steps.
+"""
+
+import logging
+from typing import Any
+
+from linkml_runtime import SchemaView
+
+from linkml_map.datamodel.transformer_model import (
+    ClassDerivation,
+    PivotDirectionType,
+    PivotOperation,
+    SlotDerivation,
+)
+
+logger = logging.getLogger(__name__)
+
+DICT_OBJ = dict[str, Any]
+
+
+def perform_pivot_operation(
+    pivot_op: PivotOperation,
+    source_obj: DICT_OBJ,
+    class_deriv: ClassDerivation,
+    sv: SchemaView,
+    source_type: str,
+    target_sv: SchemaView | None = None,
+) -> DICT_OBJ | list[DICT_OBJ]:
+    """
+    Perform a pivot (MELT or UNMELT) operation.
+
+    :param pivot_op: The pivot operation configuration
+    :param source_obj: The source object to transform
+    :param class_deriv: The class derivation spec
+    :param sv: Source schema view
+    :param source_type: Source type name
+    :return: Transformed object(s)
+    """
+    if pivot_op.direction == PivotDirectionType.UNMELT:
+        return _perform_unmelt(pivot_op, source_obj, class_deriv, sv, source_type, target_sv)
+    elif pivot_op.direction == PivotDirectionType.MELT:
+        return perform_melt(pivot_op, source_obj, class_deriv, target_sv)
+    else:
+        msg = f"Unknown pivot direction: {pivot_op.direction}"
+        raise ValueError(msg)
+
+
+def _perform_unmelt(
+    pivot_op: PivotOperation,
+    source_obj: DICT_OBJ,
+    class_deriv: ClassDerivation,
+    sv: SchemaView,
+    source_type: str,
+    target_sv: SchemaView | None = None,
+) -> DICT_OBJ:
+    """
+    Transform EAV/long format to wide format.
+
+    Handles both single record and collection-based unmelt:
+    - Single record: {att: 'len', val: 1.0} -> {len: 1.0}
+    - Collection: [{att: 'h', val: 1.8}, {att: 'w', val: 75}] -> {h: 1.8, w: 75}
+
+    :param pivot_op: The pivot operation configuration
+    :param source_obj: The source object (may contain EAV records)
+    :param class_deriv: The class derivation spec
+    :param sv: Source schema view
+    :param source_type: Source type name
+    :return: Wide-format object
+    """
+    variable_slot = pivot_op.variable_slot or "variable"
+    value_slot = pivot_op.value_slot or "value"
+    unit_slot = pivot_op.unit_slot
+    template = pivot_op.slot_name_template or "{variable}"
+
+    # Check if source_obj itself is an EAV record (has variable and value slots)
+    if variable_slot in source_obj and value_slot in source_obj:
+        return _unmelt_single_record(pivot_op, source_obj, variable_slot, value_slot, unit_slot, template, target_sv)
+
+    # Otherwise, look for a collection of EAV records in the source
+    # Try to find a multivalued slot containing EAV records
+    for slot_name, slot_value in source_obj.items():
+        if isinstance(slot_value, list) and len(slot_value) > 0:
+            first_item = slot_value[0]
+            if isinstance(first_item, dict) and variable_slot in first_item:
+                return _unmelt_collection(pivot_op, slot_value)
+
+    # Fallback: treat source_obj as a single EAV record
+    return _unmelt_single_record(pivot_op, source_obj, variable_slot, value_slot, unit_slot, template, target_sv)
+
+
+def _unmelt_single_record(
+    pivot_op: PivotOperation,
+    record: DICT_OBJ,
+    variable_slot: str,
+    value_slot: str,
+    unit_slot: str | None,
+    template: str,
+    target_sv: SchemaView | None = None,
+) -> DICT_OBJ:
+    """
+    Unmelt a single EAV record into slot assignment(s).
+
+    Example:
+        Input:  {att: 'len', val: 1.0, unit: 'm'}
+        Output: {len_m: 1.0}
+    """
+    result = {}
+
+    # Copy ID slots (non-pivoted attributes)
+    if pivot_op.id_slots:
+        for id_slot in pivot_op.id_slots:
+            if id_slot in record:
+                result[id_slot] = record[id_slot]
+
+    # Get variable and value
+    variable = record.get(variable_slot)
+    value = record.get(value_slot)
+
+    if variable is None:
+        logger.warning(f"No variable found in slot '{variable_slot}'")
+        return result
+
+    # Generate target slot name
+    if unit_slot and unit_slot in record:
+        unit = record[unit_slot]
+        target_slot_name = template.format(variable=variable, unit=unit)
+    else:
+        target_slot_name = template.format(variable=variable, unit="")
+
+    # Validate against target schema if unmelt_to_class specified
+    if pivot_op.unmelt_to_class and target_sv:
+        valid_slots = [s.name for s in target_sv.class_induced_slots(pivot_op.unmelt_to_class)]
+        if pivot_op.unmelt_to_slots:
+            valid_slots = [s for s in valid_slots if s in pivot_op.unmelt_to_slots]
+
+        if target_slot_name not in valid_slots:
+            logger.warning(
+                f"Generated slot name '{target_slot_name}' not in valid slots for class '{pivot_op.unmelt_to_class}'"
+            )
+
+    result[target_slot_name] = value
+    return result
+
+
+def _unmelt_collection(
+    pivot_op: PivotOperation,
+    records: list[DICT_OBJ],
+) -> DICT_OBJ:
+    """
+    Unmelt a collection of EAV records into a single wide object.
+
+    Example:
+        Input:  [{att: 'height', val: 1.8}, {att: 'weight', val: 75.0}]
+        Output: {height: 1.8, weight: 75.0}
+    """
+    result = {}
+    variable_slot = pivot_op.variable_slot or "variable"
+    value_slot = pivot_op.value_slot or "value"
+    unit_slot = pivot_op.unit_slot
+    template = pivot_op.slot_name_template or "{variable}"
+
+    for record in records:
+        variable = record.get(variable_slot)
+        value = record.get(value_slot)
+
+        if variable is None:
+            continue
+
+        if unit_slot and unit_slot in record:
+            unit = record[unit_slot]
+            target_slot = template.format(variable=variable, unit=unit)
+        else:
+            target_slot = template.format(variable=variable, unit="")
+
+        if target_slot in result:
+            logger.warning(f"Duplicate variable '{variable}' in unmelt; last value wins")
+
+        result[target_slot] = value
+
+    # Copy ID slots from the first record (assuming they're the same across all)
+    if pivot_op.id_slots and records:
+        for id_slot in pivot_op.id_slots:
+            if id_slot in records[0]:
+                result[id_slot] = records[0][id_slot]
+
+    return result
+
+
+def perform_melt(
+    pivot_op: PivotOperation,
+    source_obj: DICT_OBJ,
+    slot_derivation: SlotDerivation | None = None,
+    target_sv: SchemaView | None = None,
+) -> list[DICT_OBJ]:
+    """
+    Transform wide format to EAV/long format.
+
+    Example:
+        Input:  {height: 1.8, weight: 75.0}
+        Output: [{variable: 'height', value: 1.8}, {variable: 'weight', value: 75.0}]
+
+    :param pivot_op: The pivot operation configuration
+    :param source_obj: The source object in wide format
+    :param slot_derivation: Optional slot derivation (for context)
+    :return: List of EAV records
+    """
+    variable_slot = pivot_op.variable_slot or "variable"
+    value_slot = pivot_op.value_slot or "value"
+
+    # Determine which slots to melt
+    if pivot_op.source_slots:
+        slots_to_melt = list(pivot_op.source_slots)
+    elif pivot_op.unmelt_to_class and target_sv:
+        # Infer from target class
+        slots_to_melt = [s.name for s in target_sv.class_induced_slots(pivot_op.unmelt_to_class)]
+    else:
+        # Melt all non-ID slots
+        id_slots = set(pivot_op.id_slots or [])
+        slots_to_melt = [k for k in source_obj.keys() if k not in id_slots]
+
+    results = []
+    base_record = {}
+
+    # Copy ID slots to base record
+    if pivot_op.id_slots:
+        for id_slot in pivot_op.id_slots:
+            if id_slot in source_obj:
+                base_record[id_slot] = source_obj[id_slot]
+
+    # Create one record per melted slot
+    for slot_name in slots_to_melt:
+        if slot_name in source_obj and source_obj[slot_name] is not None:
+            record = base_record.copy()
+            record[variable_slot] = slot_name
+            record[value_slot] = source_obj[slot_name]
+            results.append(record)
+
+    return results


### PR DESCRIPTION
Closes #304. Pure move — no new abstraction, no behaviour change.

`object_transformer.py` drops from **1558 to 1246 lines**.

### Pivot / EAV → `transformer/pivot.py`

Five functions (`perform_pivot_operation`, `_perform_unmelt`, `_unmelt_single_record`, `_unmelt_collection`, `perform_melt`), reached from two call sites and calling nothing else in the class.

An AST pass over the block confirmed the issue's claim about instance state, and it was cleaner than described — only `_unmelt_single_record` and `perform_melt` touched `self` at all, both solely for `target_schemaview`, which is now an explicit parameter threaded through the two callers.

### Unit conversion → `functions/unit_conversion.py`

`perform_unit_conversion` lands next to `convert_units` and `UnitSystem`, which it already depended on.

It referenced **zero** instance state — everything came through `DerivationContext`. But that type is defined in `object_transformer`, which imports this module, so keeping the parameter would have made the import circular. It now takes the three fields it actually used (`source_obj`, `sv`, `source_type`) directly, which is what the issue proposed by "taking the schemaview explicitly". Verified there's no cycle by importing both modules standalone.

### On the #298 overlap

The issue flagged that the mock tests drove the private `_perform_unit_conversion` directly, so whichever landed second had to account for the other. #323 landed first and replaced them with end-to-end tests through `map_object` — which is why this extraction needed **no test changes at all**. Had the mocks still been in place, all seven would have broken on a refactor that changes no behaviour. Confirmed nothing outside the class referenced any of the six moved methods.

### Verification

1102 passed, 4 skipped, 1 xfailed — identical to main, since the existing pivot (9) and unit-conversion (7) tests already exercise this code end-to-end. ruff and format clean.