### PR TITLE
Compile nested class derivations to DuckDB structs

### DIFF
--- a/src/linkml_map/compiler/sql_compiler.py
+++ b/src/linkml_map/compiler/sql_compiler.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import SlotDefinition
 
@@ -5,8 +7,10 @@ from linkml_map.compiler.compiler import CompiledSpecification, Compiler
 from linkml_map.datamodel.transformer_model import (
     ClassDerivation,
     SerializationSyntaxType,
+    SlotDerivation,
     TransformationSpecification,
 )
+from linkml_map.utils.join_utils import join_keys
 
 LINKML_TO_SQL_TYPE_MAP = {
     "string": "TEXT",
@@ -21,13 +25,39 @@ LINKML_TO_SQL_TYPE_MAP = {
     "any": "TEXT",
 }
 
+#: Alias bound to the primary (``populated_from``) table in a compiled SELECT.
+PRIMARY_ALIAS = "_src"
 
+
+def _quote(identifier: str) -> str:
+    """Quote a SQL identifier for DuckDB, escaping embedded double quotes."""
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _literal(value: str) -> str:
+    """Render a SQL string literal for DuckDB, escaping embedded single quotes."""
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+@dataclass
 class SQLCompiler(Compiler):
     """
     Compiles a Transformation Specification to SQL CREATE TABLE or VIEW statements.
 
     Note: this is currently highly geared towards DuckDB.
+
+    Nested ``class_derivations`` compile to DuckDB ``STRUCT`` values rather than
+    being normalized into side tables, so a nested field is a column access for
+    consumers rather than a join. Nested shape and cardinality are read from
+    ``target_schemaview`` — the *real* target schema, not
+    :meth:`Compiler.derived_target_schemaview`, which does not derive nested
+    classes and reports every nested slot as a plain ``string``.
     """
+
+    target_schemaview: SchemaView | None = None
+    """A view over the schema describing the target.  Required for nested derivations."""
 
     add_if_not_exists: bool = True
     new_table_when_transforming: bool = False
@@ -52,6 +82,15 @@ class SQLCompiler(Compiler):
         :param specification:
         :return:
         """
+        col_names = []
+        col_trs = []
+        for sd in cd.slot_derivations.values():
+            if sd.hide:
+                continue
+            col_names.append(sd.name)
+            col_trs.append(self.compile_slot_derivation(sd, cd, cd.name, PRIMARY_ALIAS))
+        if not col_trs:
+            return
         stmt = ""
         if self.new_table_when_transforming:
             stmt += "CREATE TABLE "
@@ -59,22 +98,39 @@ class SQLCompiler(Compiler):
                 stmt += "IF NOT EXISTS "
             stmt += f"{cd.name} \n"
         else:
-            stmt += f"INSERT INTO {cd.name} SELECT \n"
-        col_trs = []
-        for sd in cd.slot_derivations.values():
-            if sd.hide:
-                continue
-            col_trs.append(self.compile_slot_derivation(sd))
-        if not col_trs:
-            return
+            # An explicit column list is required because a specification generally derives
+            # only some of the target's columns; a bare INSERT ... SELECT demands all of them.
+            columns = ", ".join(_quote(name) for name in col_names)
+            stmt += f"INSERT INTO {cd.name} ({columns}) SELECT \n"
         stmt += ", \n".join(col_trs)
-        stmt += f" FROM {cd.populated_from or cd.name}"
+        stmt += f" FROM {cd.populated_from or cd.name} AS {PRIMARY_ALIAS}"
         compiled.serialization += f"{stmt};\n"
 
-    def compile_slot_derivation(self, sd) -> str:
+    def compile_slot_derivation(
+        self,
+        sd: SlotDerivation,
+        parent_cd: ClassDerivation | None = None,
+        target_class: str | None = None,
+        table_alias: str = PRIMARY_ALIAS,
+    ) -> str:
+        """
+        Compile one slot derivation to a ``<expression> AS <name>`` select item.
+
+        :param sd: The slot derivation to compile.
+        :param parent_cd: The class derivation owning *sd*, which carries the join specs
+            a cross-table nested derivation needs.
+        :param target_class: Name of the target class *sd* belongs to, used to look up the
+            target slot's cardinality and range.
+        :param table_alias: Alias of the table whose columns *sd* reads.
+        :return: A select item.
+        """
+        if sd.class_derivations:
+            expr = self._compile_nested(sd, parent_cd, target_class, table_alias)
+            return f"  {expr} AS {_quote(sd.name)}"
         expr = sd.populated_from
         if expr is None:
             expr = sd.name
+        expr = f"{table_alias}.{expr}"
         if sd.stringification:
             syntax = sd.stringification.syntax
             delimiter = sd.stringification.delimiter
@@ -84,8 +140,148 @@ class SQLCompiler(Compiler):
             elif syntax == SerializationSyntaxType.JSON:
                 expr = f"CAST({expr} AS TEXT)"
             elif delimiter:
-                expr = f"STRING_AGG({expr}, '{delimiter}')"
+                expr = f"STRING_AGG({expr}, {_literal(delimiter)})"
         return f"  {expr} AS {sd.name}"
+
+    def _target_slot(self, slot_name: str, target_class: str | None) -> SlotDefinition:
+        """
+        Resolve a target slot definition, which carries the nested shape and cardinality.
+
+        :param slot_name: Name of the target slot.
+        :param target_class: Name of the target class owning the slot.
+        :raises ValueError: If no target schema is available, or the slot is not found.
+        """
+        if self.target_schemaview is None or target_class is None:
+            msg = (
+                f"Compiling nested class_derivations for slot {slot_name!r} requires a target "
+                "schema; construct SQLCompiler(target_schemaview=...) so the nested STRUCT "
+                "shape and cardinality can be resolved."
+            )
+            raise ValueError(msg)
+        slot = self.target_schemaview.induced_slot(slot_name, target_class)
+        if slot is None:
+            msg = f"Target slot {target_class}.{slot_name} not found in the target schema"
+            raise ValueError(msg)
+        return slot
+
+    def _compile_nested(
+        self,
+        sd: SlotDerivation,
+        parent_cd: ClassDerivation | None,
+        target_class: str | None,
+        table_alias: str,
+    ) -> str:
+        """
+        Compile a slot derivation carrying nested ``class_derivations`` to a STRUCT expression.
+
+        Same-row nesting (the nested derivation reads the parent's table) becomes an inline
+        struct literal.  Cross-table nesting becomes a correlated subquery over the joined
+        table, so multiple multivalued nested slots on one class cannot form a cartesian
+        product the way a ``GROUP BY`` over repeated joins would.
+
+        :param sd: The slot derivation declaring nested class derivations.
+        :param parent_cd: The class derivation owning *sd*, carrying its join specs.
+        :param target_class: Name of the target class *sd* belongs to.
+        :param table_alias: Alias of the table the parent derivation reads.
+        :return: A DuckDB expression yielding a STRUCT or a list of STRUCTs.
+        :raises ValueError: If the nesting cannot be compiled unambiguously.
+        """
+        target_slot = self._target_slot(sd.name, target_class)
+        multivalued = bool(target_slot.multivalued)
+        if len(sd.class_derivations) > 1 and not multivalued:
+            msg = (
+                f"Slot {target_class}.{sd.name} declares {len(sd.class_derivations)} nested "
+                "class_derivations but is single-valued in the target schema; only a "
+                "multivalued slot can hold more than one derived object."
+            )
+            raise ValueError(msg)
+
+        parent_source = (parent_cd.populated_from or parent_cd.name) if parent_cd else None
+        exprs = [
+            self._compile_nested_one(cd, sd, parent_cd, parent_source, table_alias, multivalued, index)
+            for index, cd in enumerate(sd.class_derivations)
+        ]
+        if not multivalued:
+            return exprs[0]
+        if len(exprs) == 1:
+            return exprs[0]
+        return f"list_concat({', '.join(exprs)})"
+
+    def _compile_nested_one(
+        self,
+        cd: ClassDerivation,
+        sd: SlotDerivation,
+        parent_cd: ClassDerivation | None,
+        parent_source: str | None,
+        table_alias: str,
+        multivalued: bool,
+        index: int,
+    ) -> str:
+        """
+        Compile a single nested class derivation to a struct (or list-of-struct) expression.
+
+        :param cd: The nested class derivation.
+        :param sd: The slot derivation declaring it.
+        :param parent_cd: The class derivation owning *sd*, carrying its join specs.
+        :param parent_source: The parent derivation's source table.
+        :param table_alias: Alias of the table the parent derivation reads.
+        :param multivalued: Whether the target slot holds a list.
+        :param index: Position of *cd* among the slot's nested derivations, used to keep
+            generated table aliases unique.
+        :return: A DuckDB expression.
+        :raises ValueError: If a cross-table nesting has no join spec to resolve it.
+        """
+        nested_source = cd.populated_from or cd.name
+        if nested_source == parent_source:
+            struct = self._struct_literal(cd, table_alias)
+            return f"list_value({struct})" if multivalued else struct
+
+        joins = parent_cd.joins if parent_cd else None
+        if not joins or nested_source not in joins:
+            msg = (
+                f"Nested class {cd.name!r} has populated_from={nested_source!r} which differs "
+                f"from parent populated_from={parent_source!r}, but no join is declared for it. "
+                "Add an explicit joins: block to the parent class derivation."
+            )
+            raise ValueError(msg)
+        source_key, lookup_key = join_keys(joins[nested_source])
+        nested_alias = f"{table_alias}_j{index}"
+        struct = self._struct_literal(cd, nested_alias)
+        projection = f"list({struct})" if multivalued else struct
+        subquery = (
+            f"SELECT {projection} FROM {nested_source} AS {nested_alias} "
+            f"WHERE {nested_alias}.{lookup_key} = {table_alias}.{source_key}"
+        )
+        if multivalued:
+            # A join miss yields an empty list rather than NULL, matching the Python
+            # backend, which appends nothing and assigns the empty list (see #217).
+            return f"COALESCE(({subquery}), [])"
+        return f"({subquery} LIMIT 1)"
+
+    def _struct_literal(self, cd: ClassDerivation, table_alias: str) -> str:
+        """
+        Render a nested class derivation's slots as a DuckDB struct literal.
+
+        DuckDB casts struct literals to a declared STRUCT column by field name, so the
+        field order here need not match the column's declared order.
+
+        :param cd: The nested class derivation.
+        :param table_alias: Alias of the table its slots read.
+        :return: A DuckDB struct literal.
+        """
+        fields = []
+        for nested_sd in cd.slot_derivations.values():
+            if nested_sd.hide:
+                continue
+            if nested_sd.class_derivations:
+                value = self._compile_nested(nested_sd, cd, cd.name, table_alias)
+            else:
+                value = f"{table_alias}.{nested_sd.populated_from or nested_sd.name}"
+            fields.append(f"{_literal(nested_sd.name)}: {value}")
+        if not fields:
+            msg = f"Nested class derivation {cd.name!r} has no visible slot derivations"
+            raise ValueError(msg)
+        return "{" + ", ".join(fields) + "}"
 
     def create_ddl(self, schemaview: SchemaView) -> str:
         """
@@ -117,25 +313,67 @@ class SQLCompiler(Compiler):
         target_sv = self.derived_target_schemaview(specification)
         return self.create_ddl(target_sv)
 
-    def sql_type(self, slot: SlotDefinition, schemaview: SchemaView) -> str:
+    def sql_type(self, slot: SlotDefinition, schemaview: SchemaView, _enclosing: frozenset[str] = frozenset()) -> str:
         """
         Map LinkML types to DuckDB SQL types.
 
-        :param slot:
-        :param schemaview:
-        :return:
+        An inlined class-ranged slot carries a nested object and becomes a ``STRUCT`` of that
+        class's own columns; a non-inlined one is a reference and becomes the identifier's type.
+
+        :param slot: The slot to type.
+        :param schemaview: Schema the slot's range is resolved against.
+        :param _enclosing: Classes already being expanded, guarding against recursive ranges.
+        :return: A DuckDB type.
         """
         typ = "TEXT"
         if slot.range:
             if slot.range in LINKML_TO_SQL_TYPE_MAP:
                 typ = LINKML_TO_SQL_TYPE_MAP.get(slot.range, typ)
             elif slot.range in schemaview.all_classes():
-                if slot.inlined:
-                    typ = "TEXT"
+                if slot.inlined or slot.inlined_as_list:
+                    typ = self.struct_type(slot.range, schemaview, _enclosing)
                 else:
-                    # TODO: consider structs
-                    typ = "JSON"
+                    typ = self._reference_type(slot.range, schemaview)
 
         if slot.multivalued:
             typ = f"{typ}[]"
         return typ
+
+    def struct_type(
+        self,
+        class_name: str,
+        schemaview: SchemaView,
+        _enclosing: frozenset[str] = frozenset(),
+    ) -> str:
+        """
+        Render a class as a DuckDB ``STRUCT`` type over its induced slots.
+
+        :param class_name: The class to expand.
+        :param schemaview: Schema the class is resolved against.
+        :param _enclosing: Classes already being expanded.  A range that recurses into one of
+            them degrades to ``JSON``, since a STRUCT type cannot be infinitely deep.
+        :return: A DuckDB ``STRUCT(...)`` type, or ``JSON`` for a recursive range.
+        """
+        if class_name in _enclosing:
+            return "JSON"
+        nested = _enclosing | {class_name}
+        field_strs = [
+            f"{_quote(s.name)} {self.sql_type(s, schemaview, nested)}"
+            for s in schemaview.class_induced_slots(class_name)
+        ]
+        if not field_strs:
+            return "JSON"
+        return f"STRUCT({', '.join(field_strs)})"
+
+    def _reference_type(self, class_name: str, schemaview: SchemaView) -> str:
+        """
+        Type of a non-inlined reference to *class_name*: the type of its identifier.
+
+        :param class_name: The referenced class.
+        :param schemaview: Schema the class is resolved against.
+        :return: A DuckDB type.
+        """
+        for s in schemaview.class_induced_slots(class_name):
+            if s.identifier or s.key:
+                return LINKML_TO_SQL_TYPE_MAP.get(s.range, "TEXT")
+        return "TEXT"

--- a/src/linkml_map/transformer/duckdb_transformer.py
+++ b/src/linkml_map/transformer/duckdb_transformer.py
@@ -45,32 +45,47 @@ class DuckDBTransformer(Transformer):
         source_database: DATABASE,
         target_database: DATABASE | None = None,
         **kwargs: Any,
-    ) -> OBJECT_TYPE:
+    ) -> DuckDBPyConnection:
         """
         Transform source resource.
 
-        :param source_database:
-        :param target_database:
+        :param source_database: Database holding the source tables, as a path or an open
+            connection.  Target tables are created alongside them and populated in place.
+        :param target_database: Must be unset or equal to *source_database*.
         :param kwargs:
-        :return:
+        :return: The connection the target tables were written to.
+        :raises NotImplementedError: If a target database distinct from the source is given.
         """
         import duckdb
-
-        if target_database is None:
-            target_database = source_database
 
         def _connect(db: DATABASE) -> DuckDBPyConnection:
             if isinstance(db, str):
                 return duckdb.connect(db)
             return db
 
-        source_connection = _connect(source_database)
-        target_connection = _connect(target_database)
-        sql_compiler = SQLCompiler()
-        source_connection.sql(sql_compiler.create_ddl(self.source_schemaview))
-        target_connection.sql(sql_compiler.create_ddl(self.target_schemaview))
+        if target_database is not None and target_database != source_database:
+            # The compiled INSERTs name source tables unqualified, so they only resolve on a
+            # connection that holds both source and target.  Spanning two databases needs an
+            # ATTACH and qualified names; until that exists, say so rather than silently
+            # leaving the target empty.
+            msg = (
+                "map_database cannot yet write to a database separate from the source. "
+                "Omit target_database to transform in place."
+            )
+            raise NotImplementedError(msg)
+
+        # One connection, not two: connecting twice to the same path (and especially to
+        # ':memory:') yields two independent databases, so the target would never see the rows.
+        connection = _connect(source_database)
+        sql_compiler = SQLCompiler(
+            source_schemaview=self.source_schemaview,
+            target_schemaview=self.target_schemaview,
+        )
+        connection.sql(sql_compiler.create_ddl(self.source_schemaview))
+        connection.sql(sql_compiler.create_ddl(self.target_schemaview))
         if not self.specification:
             msg = "No specification provided."
             raise ValueError(msg)
         compiled = sql_compiler.compile(self.specification)
-        source_connection.execute(compiled.serialization)
+        connection.execute(compiled.serialization)
+        return connection

--- a/tests/test_compiler/test_duckdb_compiler.py
+++ b/tests/test_compiler/test_duckdb_compiler.py
@@ -172,7 +172,9 @@ def test_compile(session: Session) -> None:
     conn = duckdb.connect(":memory:")
     conn.execute(source_ddl)
     conn.execute(target_ddl)
-    # TODO #150: compiled INSERTs don't yet provide every target column for
-    # arbitrary specs (the target's derived schema can include columns not
-    # named by any slot_derivation). Re-enable execution once SQLCompiler
-    # emits explicit column lists / handles full target shape.
+    # Compiled INSERTs now carry an explicit column list, so a partial spec is no longer
+    # the blocker here. What remains is a namespace collision: personinfo's source and
+    # target schemas both declare Container, source DDL runs first, and the target's
+    # `CREATE TABLE IF NOT EXISTS Container` is then a no-op — leaving Container with the
+    # source's columns. Executing the INSERTs needs source and target in separate DuckDB
+    # schemas.

--- a/tests/test_compiler/test_duckdb_nested_structs.py
+++ b/tests/test_compiler/test_duckdb_nested_structs.py
@@ -1,0 +1,518 @@
+"""
+Tests that nested class_derivations compile to DuckDB STRUCTs rather than being dropped.
+
+Covers the four nesting shapes called out in issue #151: a single nested object read from
+the parent's own row, two-level nesting, a multivalued nested object read across a join, and
+a multivalued nested object that is empty for most parent rows.
+"""
+
+import duckdb
+import pytest
+from linkml_runtime import SchemaView
+
+from linkml_map.compiler.sql_compiler import SQLCompiler
+from linkml_map.datamodel.transformer_model import (
+    ClassDerivation,
+    SlotDerivation,
+    TransformationSpecification,
+)
+
+SOURCE_SCHEMA = """
+id: https://example.org/src
+name: src
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  meas:
+    attributes:
+      meas_id:
+        identifier: true
+      set_id:
+      assay_id:
+      meas_value:
+        range: float
+      meas_unit:
+  obs_set:
+    attributes:
+      set_id:
+        identifier: true
+  assay_tbl:
+    attributes:
+      assay_id:
+        identifier: true
+      assay_name:
+      lower_value:
+        range: float
+      lower_unit:
+      upper_value:
+        range: float
+      upper_unit:
+  person_tbl:
+    attributes:
+      person_id:
+        identifier: true
+  death_tbl:
+    attributes:
+      d_person_id:
+      cause:
+"""
+
+TARGET_SCHEMA = """
+id: https://example.org/tgt
+name: tgt
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Quantity:
+    attributes:
+      value:
+        range: float
+      unit:
+  Assay:
+    attributes:
+      id:
+        identifier: true
+      name:
+      lower_limit_of_detection:
+        range: Quantity
+        inlined: true
+      upper_limit_of_detection:
+        range: Quantity
+        inlined: true
+  MeasurementObservation:
+    attributes:
+      id:
+        identifier: true
+      value_quantity:
+        range: Quantity
+        inlined: true
+      associated_assay:
+        range: Assay
+        inlined: true
+  MeasurementObservationSet:
+    attributes:
+      id:
+        identifier: true
+      observations:
+        range: MeasurementObservation
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+  CauseOfDeath:
+    attributes:
+      cause:
+  Person:
+    attributes:
+      id:
+        identifier: true
+      cause_of_death:
+        range: CauseOfDeath
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+"""
+
+
+def _quantity_derivation(name: str, source: str, value_col: str, unit_col: str) -> ClassDerivation:
+    """Build a Quantity derivation reading *value_col* / *unit_col* from *source*."""
+    return ClassDerivation(
+        name=name,
+        populated_from=source,
+        slot_derivations={
+            "value": SlotDerivation(name="value", populated_from=value_col),
+            "unit": SlotDerivation(name="unit", populated_from=unit_col),
+        },
+    )
+
+
+@pytest.fixture
+def source_schemaview() -> SchemaView:
+    """View over the flat relational source schema."""
+    return SchemaView(SOURCE_SCHEMA)
+
+
+@pytest.fixture
+def target_schemaview() -> SchemaView:
+    """View over the nested target schema."""
+    return SchemaView(TARGET_SCHEMA)
+
+
+@pytest.fixture
+def compiler(source_schemaview: SchemaView, target_schemaview: SchemaView) -> SQLCompiler:
+    """SQLCompiler wired to both schemas, as DuckDBTransformer wires it."""
+    return SQLCompiler(source_schemaview=source_schemaview, target_schemaview=target_schemaview)
+
+
+@pytest.fixture
+def connection(compiler: SQLCompiler, source_schemaview: SchemaView, target_schemaview: SchemaView):
+    """In-memory DuckDB holding source and target tables, with source rows loaded."""
+    con = duckdb.connect(":memory:")
+    con.execute(compiler.create_ddl(source_schemaview))
+    con.execute(compiler.create_ddl(target_schemaview))
+    con.execute("INSERT INTO obs_set VALUES ('s1'), ('s2');")
+    con.execute("INSERT INTO assay_tbl VALUES ('a1', 'glucose panel', 0.5, 'mg/dL', 500.0, 'mg/dL');")
+    con.execute("INSERT INTO meas VALUES ('m1', 's1', 'a1', 1.5, 'mg/dL'), ('m2', 's1', 'a1', 2.5, 'mg/dL');")
+    con.execute("INSERT INTO person_tbl VALUES ('p1'), ('p2');")
+    con.execute("INSERT INTO death_tbl VALUES ('p1', 'heart failure');")
+    return con
+
+
+def test_single_nested_same_row_becomes_a_struct(compiler: SQLCompiler, connection) -> None:
+    """A nested derivation reading the parent's own row compiles to an inline struct.
+
+    Shape 1: MeasurementObservation.value_quantity -> Quantity, both from `meas`.
+    """
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                slot_derivations={
+                    "id": SlotDerivation(name="id", populated_from="meas_id"),
+                    "value_quantity": SlotDerivation(
+                        name="value_quantity",
+                        class_derivations=[_quantity_derivation("Quantity", "meas", "meas_value", "meas_unit")],
+                    ),
+                },
+            ),
+        },
+    )
+    connection.execute(compiler.compile(spec).serialization)
+    rows = connection.execute(
+        "SELECT id, value_quantity.value, value_quantity.unit FROM MeasurementObservation ORDER BY id;"
+    ).fetchall()
+    assert rows == [("m1", 1.5, "mg/dL"), ("m2", 2.5, "mg/dL")]
+
+
+def test_two_level_nesting_across_a_join(compiler: SQLCompiler, connection) -> None:
+    """Nesting recurses: an Assay struct carries Quantity structs of its own.
+
+    Shape 2: MeasurementObservation.associated_assay -> Assay (joined from `assay_tbl`),
+    whose limits of detection are themselves Quantity.
+    """
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                joins={"assay_tbl": {"alias": "assay_tbl", "join_on": "assay_id"}},
+                slot_derivations={
+                    "id": SlotDerivation(name="id", populated_from="meas_id"),
+                    "associated_assay": SlotDerivation(
+                        name="associated_assay",
+                        class_derivations=[
+                            ClassDerivation(
+                                name="Assay",
+                                populated_from="assay_tbl",
+                                slot_derivations={
+                                    "id": SlotDerivation(name="id", populated_from="assay_id"),
+                                    "name": SlotDerivation(name="name", populated_from="assay_name"),
+                                    "lower_limit_of_detection": SlotDerivation(
+                                        name="lower_limit_of_detection",
+                                        class_derivations=[
+                                            _quantity_derivation("Quantity", "assay_tbl", "lower_value", "lower_unit")
+                                        ],
+                                    ),
+                                    "upper_limit_of_detection": SlotDerivation(
+                                        name="upper_limit_of_detection",
+                                        class_derivations=[
+                                            _quantity_derivation("Quantity", "assay_tbl", "upper_value", "upper_unit")
+                                        ],
+                                    ),
+                                },
+                            )
+                        ],
+                    ),
+                },
+            ),
+        },
+    )
+    connection.execute(compiler.compile(spec).serialization)
+    rows = connection.execute(
+        "SELECT id, associated_assay.name, "
+        "associated_assay.lower_limit_of_detection.value, "
+        "associated_assay.upper_limit_of_detection.unit "
+        "FROM MeasurementObservation ORDER BY id;"
+    ).fetchall()
+    assert rows == [
+        ("m1", "glucose panel", 0.5, "mg/dL"),
+        ("m2", "glucose panel", 0.5, "mg/dL"),
+    ]
+
+
+def test_multivalued_nested_becomes_a_list_of_structs(compiler: SQLCompiler, connection) -> None:
+    """A multivalued nested derivation across a join compiles to a list of structs.
+
+    Shape 3: MeasurementObservationSet.observations -> [MeasurementObservation], joined
+    from `meas`, each carrying a nested Quantity of its own.
+    """
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservationSet": ClassDerivation(
+                name="MeasurementObservationSet",
+                populated_from="obs_set",
+                joins={"meas": {"alias": "meas", "join_on": "set_id"}},
+                slot_derivations={
+                    "id": SlotDerivation(name="id", populated_from="set_id"),
+                    "observations": SlotDerivation(
+                        name="observations",
+                        class_derivations=[
+                            ClassDerivation(
+                                name="MeasurementObservation",
+                                populated_from="meas",
+                                slot_derivations={
+                                    "id": SlotDerivation(name="id", populated_from="meas_id"),
+                                    "value_quantity": SlotDerivation(
+                                        name="value_quantity",
+                                        class_derivations=[
+                                            _quantity_derivation("Quantity", "meas", "meas_value", "meas_unit")
+                                        ],
+                                    ),
+                                },
+                            )
+                        ],
+                    ),
+                },
+            ),
+        },
+    )
+    connection.execute(compiler.compile(spec).serialization)
+    rows = connection.execute("SELECT id, observations FROM MeasurementObservationSet WHERE id = 's1';").fetchall()
+    assert rows == [
+        (
+            "s1",
+            [
+                {"id": "m1", "value_quantity": {"value": 1.5, "unit": "mg/dL"}, "associated_assay": None},
+                {"id": "m2", "value_quantity": {"value": 2.5, "unit": "mg/dL"}, "associated_assay": None},
+            ],
+        )
+    ]
+
+
+def test_multivalued_nested_is_empty_when_the_join_misses(compiler: SQLCompiler, connection) -> None:
+    """A parent with no matching child rows gets an empty list, not a hollow struct.
+
+    Shape 4: Person.cause_of_death is emitted for living participants too.  Matching the
+    Python backend, a join miss yields [] rather than NULL or a struct of nulls (#217).
+    """
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "Person": ClassDerivation(
+                name="Person",
+                populated_from="person_tbl",
+                joins={
+                    "death_tbl": {
+                        "alias": "death_tbl",
+                        "source_key": "person_id",
+                        "lookup_key": "d_person_id",
+                    }
+                },
+                slot_derivations={
+                    "id": SlotDerivation(name="id", populated_from="person_id"),
+                    "cause_of_death": SlotDerivation(
+                        name="cause_of_death",
+                        class_derivations=[
+                            ClassDerivation(
+                                name="CauseOfDeath",
+                                populated_from="death_tbl",
+                                slot_derivations={
+                                    "cause": SlotDerivation(name="cause", populated_from="cause"),
+                                },
+                            )
+                        ],
+                    ),
+                },
+            ),
+        },
+    )
+    connection.execute(compiler.compile(spec).serialization)
+    rows = connection.execute("SELECT id, cause_of_death FROM Person ORDER BY id;").fetchall()
+    assert rows == [
+        ("p1", [{"cause": "heart failure"}]),
+        ("p2", []),
+    ]
+
+
+def test_map_database_writes_nested_structs_to_the_target(
+    source_schemaview: SchemaView, target_schemaview: SchemaView, connection
+) -> None:
+    """End-to-end: DuckDBTransformer.map_database lands nested structs in the target table.
+
+    Previously the compiled INSERTs ran against the source connection, so the target held
+    nothing but its DDL, and the two connections opened on ':memory:' were separate databases.
+    """
+    from linkml_map.transformer.duckdb_transformer import DuckDBTransformer
+
+    tr = DuckDBTransformer()
+    tr.source_schemaview = source_schemaview
+    tr.target_schemaview = target_schemaview
+    tr.specification = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                slot_derivations={
+                    "id": SlotDerivation(name="id", populated_from="meas_id"),
+                    "value_quantity": SlotDerivation(
+                        name="value_quantity",
+                        class_derivations=[_quantity_derivation("Quantity", "meas", "meas_value", "meas_unit")],
+                    ),
+                },
+            ),
+        },
+    )
+    result = tr.map_database(connection)
+    rows = result.execute("SELECT id, value_quantity.value FROM MeasurementObservation ORDER BY id;").fetchall()
+    assert rows == [("m1", 1.5), ("m2", 2.5)]
+
+
+def test_map_database_rejects_a_separate_target_database(
+    source_schemaview: SchemaView, target_schemaview: SchemaView
+) -> None:
+    """Writing to a database other than the source is refused rather than silently empty."""
+    from linkml_map.transformer.duckdb_transformer import DuckDBTransformer
+
+    tr = DuckDBTransformer()
+    tr.source_schemaview = source_schemaview
+    tr.target_schemaview = target_schemaview
+    tr.specification = TransformationSpecification(id="test", class_derivations={})
+    with pytest.raises(NotImplementedError, match="separate from the source"):
+        tr.map_database("source.db", "target.db")
+
+
+def test_inlined_class_range_becomes_a_struct_column(compiler: SQLCompiler, target_schemaview: SchemaView) -> None:
+    """DDL for an inlined class-ranged slot is a STRUCT of that class's columns, not TEXT."""
+    slot = target_schemaview.induced_slot("value_quantity", "MeasurementObservation")
+    assert compiler.sql_type(slot, target_schemaview) == 'STRUCT("value" REAL, "unit" TEXT)'
+
+
+def test_multivalued_inlined_class_range_becomes_a_struct_list(
+    compiler: SQLCompiler, target_schemaview: SchemaView
+) -> None:
+    """A multivalued inlined class-ranged slot becomes STRUCT(...)[]."""
+    slot = target_schemaview.induced_slot("cause_of_death", "Person")
+    assert compiler.sql_type(slot, target_schemaview) == 'STRUCT("cause" TEXT)[]'
+
+
+def test_noninlined_class_range_uses_the_identifier_type(compiler: SQLCompiler) -> None:
+    """A non-inlined class-ranged slot is a reference, typed as its target's identifier.
+
+    Previously this branch emitted JSON while the *inlined* branch emitted TEXT — the
+    inverse of what each slot actually holds.
+    """
+    schema = TARGET_SCHEMA.replace(
+        """      value_quantity:
+        range: Quantity
+        inlined: true""",
+        """      value_quantity:
+        range: Assay""",
+    )
+    sv = SchemaView(schema)
+    slot = sv.induced_slot("value_quantity", "MeasurementObservation")
+    assert compiler.sql_type(slot, sv) == "TEXT"
+
+
+def test_recursive_range_degrades_to_json(compiler: SQLCompiler) -> None:
+    """A class whose inlined range reaches itself cannot be an infinitely deep STRUCT."""
+    schema = """
+id: https://example.org/rec
+name: rec
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Node:
+    attributes:
+      label:
+      child:
+        range: Node
+        inlined: true
+"""
+    sv = SchemaView(schema)
+    slot = sv.induced_slot("child", "Node")
+    assert compiler.sql_type(slot, sv) == 'STRUCT("label" TEXT, "child" JSON)'
+
+
+def test_cross_table_nesting_without_a_join_is_an_error(compiler: SQLCompiler) -> None:
+    """A nested derivation from another table with no join spec must fail loudly.
+
+    The previous fallback emitted `<slot> AS <slot>`, referencing a source column that does
+    not exist — a binder error at execution, or silently wrong data if the name collides.
+    """
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                slot_derivations={
+                    "associated_assay": SlotDerivation(
+                        name="associated_assay",
+                        class_derivations=[
+                            ClassDerivation(name="Assay", populated_from="assay_tbl"),
+                        ],
+                    ),
+                },
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match="no join is declared"):
+        compiler.compile(spec)
+
+
+def test_nesting_without_a_target_schema_is_an_error(source_schemaview: SchemaView) -> None:
+    """Nested derivations need the target schema to resolve cardinality, so say so."""
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                slot_derivations={
+                    "value_quantity": SlotDerivation(
+                        name="value_quantity",
+                        class_derivations=[_quantity_derivation("Quantity", "meas", "meas_value", "meas_unit")],
+                    ),
+                },
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match="requires a target schema"):
+        SQLCompiler(source_schemaview=source_schemaview).compile(spec)
+
+
+def test_multiple_nested_derivations_on_a_single_valued_slot_is_an_error(compiler: SQLCompiler) -> None:
+    """Two nested derivations cannot collapse into one single-valued slot."""
+    spec = TransformationSpecification(
+        id="test",
+        class_derivations={
+            "MeasurementObservation": ClassDerivation(
+                name="MeasurementObservation",
+                populated_from="meas",
+                slot_derivations={
+                    "value_quantity": SlotDerivation(
+                        name="value_quantity",
+                        class_derivations=[
+                            _quantity_derivation("Quantity", "meas", "meas_value", "meas_unit"),
+                            _quantity_derivation("Quantity", "meas", "meas_value", "meas_unit"),
+                        ],
+                    ),
+                },
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match="single-valued"):
+        compiler.compile(spec)

--- a/tests/test_transformer/test_duckdb_transformer.py
+++ b/tests/test_transformer/test_duckdb_transformer.py
@@ -28,6 +28,13 @@ def session() -> Session:
 
 
 def test_compile(session: Session) -> None:
-    """Test compilation using the DuckDb transformer."""
-    pytest.skip("TODO")
+    """Test compilation using the DuckDb transformer.
+
+    Still skipped, but no longer for want of a working map_database — see
+    ``test_duckdb_nested_structs.py`` for end-to-end coverage on schemas whose class names
+    don't collide. personinfo's source and target both declare ``Container``, so the target
+    DDL's ``CREATE TABLE IF NOT EXISTS`` is a no-op and ``Container`` keeps the source's
+    columns. Unskipping needs source and target in separate DuckDB schemas.
+    """
+    pytest.skip("source and target schemas both declare Container; needs schema namespacing")
     session.transformer.map_database(":memory:")


### PR DESCRIPTION
Addresses the nested-derivation gap described in #151.

`SQLCompiler` never read `sd.class_derivations`, so a nested slot fell through to `<name> AS <name>` — a reference to a source column that doesn't exist, which is a binder error at execution or silently wrong data if the name happens to collide. Nesting now compiles to DuckDB `STRUCT` values, covering all four shapes the synthetic BDCHM corpus exercises:

```sql
INSERT INTO MeasurementObservationSet ("id", "observations") SELECT
  _src.set_id AS id,
  COALESCE((SELECT list({'id': _src_j0.meas_id, 'value_quantity': {'value': _src_j0.meas_value, 'unit': _src_j0.meas_unit}}) FROM meas AS _src_j0 WHERE _src_j0.set_id = _src.set_id), []) AS "observations" FROM obs_set AS _src;
```

Same-row nesting becomes an inline struct literal; cross-table nesting becomes a correlated subquery. The subquery form matters: with repeated joins and a `GROUP BY`, two multivalued nested slots on one class would produce a cartesian product and duplicate entries in both lists. A join miss yields `[]` for multivalued slots, matching what the Python backend produces (#217).

Nested shape and cardinality are read from the real target schema. `derived_target_schemaview` can't serve here — `SchemaMapper` doesn't derive nested classes, and reports every nested slot as a plain `string`.

On the DDL side the two class-range branches were inverted: inlined slots (the ones actually holding a nested object) emitted `TEXT`, non-inlined references emitted `JSON`. Now inlined expands to a `STRUCT` of the class's columns and non-inlined takes its identifier's type. Recursive ranges degrade to `JSON`.

Also fixes `map_database`, which could never populate a target: it ran the compiled INSERTs against the source connection, and called `_connect` twice — for `:memory:` that yields two independent databases. A target database distinct from the source now raises instead of silently producing nothing. Compiled INSERTs carry an explicit column list, without which a partial specification fails to bind (the standing TODO in `test_duckdb_compiler.py`).

13 tests, local fixtures, no network. Full suite green.

### Found but not fixed — worth their own issues

- Source and target classes share one DuckDB namespace. personinfo declares `Container` on both sides, source DDL runs first, so the target's `CREATE TABLE IF NOT EXISTS` is a no-op and `Container` keeps the source's columns. This is why `test_duckdb_transformer.py::test_compile` still skips; its skip reason now says so. Needs separate DuckDB schemas per side.
- `SchemaMapper` doesn't derive nested classes, so `create_target_ddl` can never emit structs.
- Cross-database `map_database` needs `ATTACH` plus qualified names.