### PR TITLE
Add Parquet and DuckDB output formats

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -96,7 +96,7 @@ def main(verbose: int, quiet: bool) -> None:
 @click.option(
     "--output-format",
     "-f",
-    type=click.Choice(["yaml", "json", "jsonl", "tsv", "csv"]),
+    type=click.Choice(["yaml", "json", "jsonl", "tsv", "csv", "parquet", "duckdb"]),
     default=None,
     help="Output format. Defaults to yaml for single objects, or inferred from output file extension.",
 )
@@ -236,6 +236,7 @@ def map_data(
             transformer_specification=transformer_specification,
             output=output,
             output_format=output_format,
+            table_name=table_name,
             target_schema=target_schema,
             continue_on_error=continue_on_error,
             entity=entity,
@@ -345,6 +346,7 @@ def _map_data_single(
     transformer_specification: tuple[str, ...],
     output: str | None,
     output_format: str,
+    table_name: str | None = None,
     target_schema: str | None = None,
     continue_on_error: bool = False,
     entity: str | None = None,
@@ -382,15 +384,54 @@ def _map_data_single(
         click.echo("\n1 transformation error:", err=True)
         click.echo(f"  - {err}", err=True)
         raise SystemExit(1) from err
+    if output_format in COLUMNAR_FORMATS:
+        _dump_columnar(tr_obj, output_format, output, table_name)
+        return
     dump_output(tr_obj, output_format, output)
+
+
+#: Formats whose artifact is a binary file built by DuckDB, so they cannot go to stdout
+#: and are not handled by the text-oriented ``dump_output``.
+COLUMNAR_FORMATS = frozenset({OutputFormat.PARQUET.value, OutputFormat.DUCKDB.value})
+
+
+def _dump_columnar(
+    tr_obj: dict[str, Any] | list[Any],
+    output_format: str,
+    output: str | None,
+    table_name: str | None,
+) -> None:
+    """Write a single transformed object (or list of them) as Parquet or DuckDB.
+
+    The single-object path has no chunk stream, so the result is handed to the same
+    writers the streaming path uses as one chunk.  Without this, inferring ``parquet``
+    from an output extension on single-object input reached ``dump_output`` and raised
+    ``NotImplementedError``.
+
+    :param tr_obj: The transformed object, or a list of them.
+    :param output_format: ``parquet`` or ``duckdb``.
+    :param output: Output file path.
+    :param table_name: Table name for DuckDB output.
+    :raises click.ClickException: If no output path was given.
+    """
+    if not output:
+        msg = f"{output_format} output requires an output file; pass -o/--output FILE"
+        raise click.ClickException(msg)
+    rows = tr_obj if isinstance(tr_obj, list) else [tr_obj]
+    writer = make_stream_writer(OutputFormat(output_format), table_name=table_name)
+    MultiStreamWriter([(writer, Path(output))]).write_all(iter([rows]))
 
 
 def _build_additional_outputs(
     additional_output: tuple,
+    table_name: str | None = None,
 ) -> list[tuple[StreamWriter, Path]]:
     """Build (StreamWriter, Path) pairs for additional -O outputs.
 
     :param additional_output: Tuple of file path strings from the CLI.
+    :param table_name: Table name for DuckDB outputs, applied to every DuckDB writer this
+        command builds so ``-O out.duckdb --table-name X`` names the table consistently
+        with the primary output.
     :return: List of (StreamWriter, Path) tuples.
     :raises click.ClickException: If an extension cannot be mapped to a format.
     """
@@ -402,7 +443,7 @@ def _build_additional_outputs(
         if extra_fmt is None:
             msg = f"Cannot infer output format from extension: {ext}"
             raise click.ClickException(msg)
-        result.append((make_stream_writer(extra_fmt), extra_path))
+        result.append((make_stream_writer(extra_fmt, table_name=table_name), extra_path))
     return result
 
 
@@ -460,7 +501,11 @@ def _map_data_streaming(
         msg = f"Unsupported output format: {output_format}"
         raise click.ClickException(msg) from None
 
-    extra_outputs = _build_additional_outputs(additional_output) if additional_output else []
+    if output_format in COLUMNAR_FORMATS and not output:
+        msg = f"{output_format} output requires an output file; pass -o/--output FILE"
+        raise click.ClickException(msg)
+
+    extra_outputs = _build_additional_outputs(additional_output, table_name) if additional_output else []
 
     # Validate no duplicate paths between primary and additional outputs
     if extra_outputs and output:

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -108,6 +108,11 @@ def main(verbose: int, quiet: bool) -> None:
     help="Number of records to process per chunk (for streaming output).",
 )
 @click.option(
+    "--table-name",
+    default=None,
+    help="Table name for DuckDB output. Defaults to the output file's stem.",
+)
+@click.option(
     "-O",
     "--additional-output",
     multiple=True,
@@ -144,6 +149,7 @@ def map_data(
     output: str | None,
     output_format: str | None,
     chunk_size: int,
+    table_name: str | None,
     additional_output: tuple,
     continue_on_error: bool = False,
     target_schema: str | None = None,
@@ -213,6 +219,7 @@ def map_data(
             output=output,
             output_format=output_format,
             chunk_size=chunk_size,
+            table_name=table_name,
             additional_output=additional_output,
             target_schema=target_schema,
             continue_on_error=continue_on_error,
@@ -407,6 +414,7 @@ def _map_data_streaming(
     output: str | None,
     output_format: str,
     chunk_size: int,
+    table_name: str | None = None,
     additional_output: tuple = (),
     target_schema: str | None = None,
     continue_on_error: bool = False,
@@ -463,7 +471,7 @@ def _map_data_streaming(
             raise click.ClickException(msg)
 
     primary_target = Path(output) if output else sys.stdout
-    all_outputs = [(make_stream_writer(fmt), primary_target), *extra_outputs]
+    all_outputs = [(make_stream_writer(fmt, table_name=table_name), primary_target), *extra_outputs]
     MultiStreamWriter(all_outputs).write_all(chunks)
 
     # Errors were already printed as they occurred; a mid-stream crash would

--- a/src/linkml_map/writers/output_streams.py
+++ b/src/linkml_map/writers/output_streams.py
@@ -51,6 +51,8 @@ class OutputFormat(str, Enum):
     JSONL = "jsonl"
     TSV = "tsv"
     CSV = "csv"
+    PARQUET = "parquet"
+    DUCKDB = "duckdb"
 
 
 class StreamWriter(ABC):
@@ -92,6 +94,27 @@ class StreamWriter(ABC):
         for chunk in chunks:
             yield from self.write_chunk(chunk)
         yield from self.finalize()
+
+    def staging_path(self, target: Path) -> Path | None:
+        """
+        Path this writer's text fragments should be written to instead of *target*.
+
+        Writers whose final artifact is not the text they emit — a binary columnar file,
+        say — stage the text elsewhere and convert it in :meth:`finalize_path`, so *target*
+        never briefly holds content that doesn't match its extension.
+
+        :param target: The final output path.
+        :return: A staging path, or ``None`` to write directly to *target*.
+        """
+        return None
+
+    def finalize_path(self, target: Path, staged: Path | None) -> None:
+        """
+        Post-process a file target once every fragment has been written.
+
+        :param target: The final output path.
+        :param staged: The staging path used, if :meth:`staging_path` returned one.
+        """
 
 
 class JSONStreamWriter(StreamWriter):
@@ -432,6 +455,22 @@ class TabularStreamWriter(StreamWriter):
         """Get the final set of headers after streaming."""
         return list(self.headers)
 
+    def finalize_path(self, target: Path, staged: Path | None) -> None:  # noqa: ARG002
+        """
+        Rewrite the file with the full header set when later rows introduced new columns.
+
+        :param target: The written file.
+        :param staged: Unused; tabular output is written directly to *target*.
+        """
+        if not self._headers_changed:
+            return
+        logger.info("Rewriting %s with updated headers", target)
+        tmp_path = str(target) + ".tmp"
+        with open(target, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
+            for line in rewrite_header_and_pad(iter(src), self.get_final_headers(), self.separator):
+                dst.write(line)
+        os.replace(tmp_path, str(target))
+
 
 def tsv_stream(
     chunks: Iterator[list[dict[str, Any]]],
@@ -538,6 +577,163 @@ def rewrite_header_and_pad(
             yield _write_row(fields)
 
 
+class ColumnarStreamWriter(StreamWriter):
+    """
+    Base for writers whose artifact is built by DuckDB from staged JSON Lines.
+
+    Objects are streamed to a staging ``.jsonl`` file exactly as :class:`JSONLStreamWriter`
+    writes them, then handed to DuckDB's ``read_json_auto``, which infers a column type per
+    field — including ``STRUCT`` for nested objects and ``STRUCT[]`` for lists of them.  So
+    nesting survives into the columnar artifact as typed columns, and a nested field stays a
+    column access for consumers rather than becoming a join.
+
+    Staging keeps the streaming contract intact: transformed objects are never all held in
+    memory, and the target path only ever contains the finished artifact.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the writer with a JSONL writer to stage through."""
+        self._jsonl = JSONLStreamWriter()
+
+    def write_chunk(self, chunk: list[dict]) -> Iterator[str]:
+        """
+        Emit staged JSONL for a chunk.
+
+        :param chunk: A list of dictionaries.
+        :yield: JSONL fragments destined for the staging file.
+        """
+        yield from self._jsonl.write_chunk(chunk)
+
+    def finalize(self) -> Iterator[str]:
+        """
+        Emit any trailing staged content.
+
+        :yield: Trailing JSONL fragments.
+        """
+        yield from self._jsonl.finalize()
+
+    def staging_path(self, target: Path) -> Path:
+        """
+        Stage alongside *target* so the conversion is a local rename-free read.
+
+        :param target: The final output path.
+        :return: The staging path.
+        """
+        return target.with_name(target.name + ".staging.jsonl")
+
+    def finalize_path(self, target: Path, staged: Path | None) -> None:
+        """
+        Convert the staged JSONL into the final artifact, then remove the staging file.
+
+        :param target: The final output path.
+        :param staged: The staging path written during streaming.
+        :raises ValueError: If no staging file was produced.
+        """
+        if staged is None:
+            msg = f"{type(self).__name__} requires a staging file to convert from"
+            raise ValueError(msg)
+        import duckdb
+
+        connection = duckdb.connect(*self._connect_args(target))
+        try:
+            connection.execute(self._conversion_sql(target, staged))
+        finally:
+            connection.close()
+        staged.unlink()
+
+    def _connect_args(self, target: Path) -> tuple[str, ...]:
+        """
+        Arguments for ``duckdb.connect`` when converting.
+
+        :param target: The final output path.
+        :return: Positional arguments, empty for an in-memory connection.
+        """
+        return ()
+
+    def _conversion_sql(self, target: Path, staged: Path) -> str:
+        """
+        SQL converting *staged* into the final artifact.
+
+        :param target: The final output path.
+        :param staged: The staging JSONL path.
+        :return: A DuckDB statement.
+        """
+        raise NotImplementedError
+
+
+class ParquetStreamWriter(ColumnarStreamWriter):
+    """Writes a single Parquet file, readable outside the DuckDB ecosystem."""
+
+    def _conversion_sql(self, target: Path, staged: Path) -> str:
+        """
+        Build the ``COPY ... TO ... (FORMAT PARQUET)`` statement.
+
+        :param target: The Parquet file to write.
+        :param staged: The staging JSONL path.
+        :return: A DuckDB statement.
+        """
+        return f"COPY (SELECT * FROM read_json_auto({_sql_literal(staged)})) TO {_sql_literal(target)} (FORMAT PARQUET)"
+
+
+class DuckDBStreamWriter(ColumnarStreamWriter):
+    """
+    Writes one table into a DuckDB database file, creating the file if absent.
+
+    Repeated runs against the same path accumulate tables, so a database covering several
+    target classes is built by invoking the transform once per class.
+
+    :param table_name: Table to create.  Defaults to the output file's stem.
+    """
+
+    def __init__(self, table_name: str | None = None) -> None:
+        """Initialize the writer, optionally overriding the derived table name."""
+        super().__init__()
+        self.table_name = table_name
+
+    def _connect_args(self, target: Path) -> tuple[str, ...]:
+        """
+        Connect to the database file itself rather than an in-memory database.
+
+        :param target: The DuckDB file to write.
+        :return: Positional arguments for ``duckdb.connect``.
+        """
+        return (str(target),)
+
+    def _conversion_sql(self, target: Path, staged: Path) -> str:
+        """
+        Build the ``CREATE OR REPLACE TABLE ... AS SELECT`` statement.
+
+        :param target: The DuckDB file being written.
+        :param staged: The staging JSONL path.
+        :return: A DuckDB statement.
+        """
+        table = self.table_name or target.stem
+        return (
+            f"CREATE OR REPLACE TABLE {_quote_identifier(table)} AS "
+            f"SELECT * FROM read_json_auto({_sql_literal(staged)})"
+        )
+
+
+def _sql_literal(path: Path) -> str:
+    """
+    Render *path* as a SQL string literal.
+
+    :param path: Path to quote.
+    :return: A single-quoted SQL literal.
+    """
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _quote_identifier(name: str) -> str:
+    """
+    Render *name* as a quoted SQL identifier.
+
+    :param name: Identifier to quote.
+    :return: A double-quoted SQL identifier.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 def get_stream_writer(output_format: OutputFormat) -> Any:
     """
     Get the appropriate stream writer for the given format.
@@ -572,6 +768,8 @@ EXTENSION_FORMAT_MAP = {
     ".jsonl": OutputFormat.JSONL,
     ".tsv": OutputFormat.TSV,
     ".csv": OutputFormat.CSV,
+    ".parquet": OutputFormat.PARQUET,
+    ".duckdb": OutputFormat.DUCKDB,
 }
 
 
@@ -579,6 +777,7 @@ def make_stream_writer(
     output_format: OutputFormat,
     key_name: str | None = None,
     separator: str | None = None,
+    table_name: str | None = None,
 ) -> StreamWriter:
     """
     Return the appropriate ``StreamWriter`` for a format.
@@ -586,9 +785,14 @@ def make_stream_writer(
     :param output_format: The desired output format.
     :param key_name: Optional key for formats that support wrapping (JSON, YAML).
     :param separator: Optional separator override for tabular formats.
+    :param table_name: Optional table name for DuckDB output.
     :return: A ``StreamWriter`` instance.
     :raises ValueError: If the format is not supported.
     """
+    if output_format == OutputFormat.PARQUET:
+        return ParquetStreamWriter()
+    if output_format == OutputFormat.DUCKDB:
+        return DuckDBStreamWriter(table_name=table_name)
     if output_format == OutputFormat.JSON:
         return JSONStreamWriter(key_name=key_name)
     if output_format == OutputFormat.JSONL:
@@ -627,13 +831,19 @@ class MultiStreamWriter:
         """
         handles: list[IO[str]] = []
         owned: list[bool] = []  # True when we opened the handle (so we close it)
+        staged: list[Path | None] = []
         try:
-            for _writer, target in self.outputs:
+            for writer, target in self.outputs:
                 if isinstance(target, Path):
-                    fh = open(target, "w", encoding="utf-8")  # noqa: SIM115
+                    # A writer whose artifact isn't the text it emits streams to a staging
+                    # file instead, and builds the real artifact in finalize_path.
+                    stage = writer.staging_path(target)
+                    staged.append(stage)
+                    fh = open(stage or target, "w", encoding="utf-8")  # noqa: SIM115
                     handles.append(fh)
                     owned.append(True)
                 else:
+                    staged.append(None)
                     handles.append(target)
                     owned.append(False)
 
@@ -653,12 +863,7 @@ class MultiStreamWriter:
                 if is_owned:
                     fh.close()
 
-        # Post-process tabular Path outputs that had header changes
-        for writer, target in self.outputs:
-            if isinstance(target, Path) and isinstance(writer, TabularStreamWriter) and writer.headers_changed:
-                logger.info("Rewriting %s with updated headers", target)
-                tmp_path = str(target) + ".tmp"
-                with open(target, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
-                    for line in rewrite_header_and_pad(iter(src), writer.get_final_headers(), writer.separator):
-                        dst.write(line)
-                os.replace(tmp_path, str(target))
+        # Let each writer build or repair its own file artifact
+        for idx, (writer, target) in enumerate(self.outputs):
+            if isinstance(target, Path):
+                writer.finalize_path(target, staged[idx])

--- a/tests/test_cli/test_cli_columnar.py
+++ b/tests/test_cli/test_cli_columnar.py
@@ -1,0 +1,99 @@
+"""CLI tests for Parquet and DuckDB output across both input paths."""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from linkml_map.cli.cli import main
+
+TABULAR_TEST_DIR = Path(__file__).parent.parent / "input" / "examples" / "tabular"
+TABULAR_DATA = TABULAR_TEST_DIR / "data" / "Person.tsv"
+TABULAR_SOURCE_SCHEMA = TABULAR_TEST_DIR / "source" / "person_flat.yaml"
+TABULAR_TRANSFORM = TABULAR_TEST_DIR / "transform" / "person_to_agent.transform.yaml"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Command line interface test runner."""
+    return CliRunner()
+
+
+def _args(output: Path | None, *extra: str) -> list[str]:
+    """Build a map-data invocation over the shared tabular fixture."""
+    args = [
+        "map-data",
+        "-T",
+        str(TABULAR_TRANSFORM),
+        "-s",
+        str(TABULAR_SOURCE_SCHEMA),
+        "--source-type",
+        "Person",
+    ]
+    if output is not None:
+        args += ["-o", str(output)]
+    return [*args, *extra, str(TABULAR_DATA)]
+
+
+def test_table_name_applies_to_additional_duckdb_outputs(runner: CliRunner, tmp_path: Path) -> None:
+    """--table-name reaches -O DuckDB writers, not just the primary output.
+
+    Previously _build_additional_outputs built its writers without the table name, so an
+    -O DuckDB file silently fell back to being named after the file stem.
+    """
+    primary = tmp_path / "primary.duckdb"
+    extra = tmp_path / "extra.duckdb"
+    result = runner.invoke(main, _args(primary, "--table-name", "agent", "-O", str(extra)))
+    assert result.exit_code == 0, result.output
+
+    for path in (primary, extra):
+        con = duckdb.connect(str(path))
+        assert [r[0] for r in con.execute("SHOW TABLES").fetchall()] == ["agent"]
+        con.close()
+
+
+def test_single_object_input_writes_parquet(runner: CliRunner, tmp_path: Path) -> None:
+    """A single YAML input infers parquet from the extension and writes it.
+
+    The non-streaming path used to reach dump_output, which raised NotImplementedError
+    for formats it had no branch for.
+    """
+    source_data = tmp_path / "person.yaml"
+    source_data.write_text(
+        "id: P:001\nname: fred bloggs\nprimary_email: fred@example.com\nage_in_years: 33\ngender: nonbinary man\n"
+    )
+    target = tmp_path / "agent.parquet"
+    result = runner.invoke(main, _args(target)[:-1] + [str(source_data)])
+    assert result.exit_code == 0, result.output
+
+    con = duckdb.connect()
+    rows = con.execute(f"SELECT id, label FROM read_parquet('{target}')").fetchall()
+    assert rows == [("P:001", "fred bloggs")]
+
+
+def test_single_object_input_writes_duckdb_with_table_name(runner: CliRunner, tmp_path: Path) -> None:
+    """--table-name is honored on the single-object path too."""
+    source_data = tmp_path / "person.yaml"
+    source_data.write_text(
+        "id: P:002\nname: jane doe\nprimary_email: jane@example.com\nage_in_years: 28\ngender: cisgender woman\n"
+    )
+    target = tmp_path / "study.duckdb"
+    result = runner.invoke(main, _args(target)[:-1] + ["--table-name", "agent", str(source_data)])
+    assert result.exit_code == 0, result.output
+
+    con = duckdb.connect(str(target))
+    assert [r[0] for r in con.execute("SHOW TABLES").fetchall()] == ["agent"]
+    assert con.execute("SELECT id FROM agent").fetchall() == [("P:002",)]
+
+
+@pytest.mark.parametrize("fmt", ["parquet", "duckdb"])
+def test_columnar_without_an_output_file_fails_cleanly(runner: CliRunner, fmt: str) -> None:
+    """These artifacts are binary files DuckDB writes, so stdout is not an option.
+
+    The failure must be a CLI error, not a traceback.
+    """
+    result = runner.invoke(main, _args(None, "--output-format", fmt))
+    assert result.exit_code != 0
+    assert "requires an output file" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_writers/test_columnar_output.py
+++ b/tests/test_writers/test_columnar_output.py
@@ -1,0 +1,145 @@
+"""
+Tests for Parquet and DuckDB output, which are built by DuckDB from staged JSON Lines.
+
+The property that matters is that nesting survives as typed columns: a nested object
+becomes a STRUCT and a list of them a STRUCT[], so a consumer reads a nested field with a
+column access rather than a join.
+"""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from linkml_map.writers.output_streams import (
+    EXTENSION_FORMAT_MAP,
+    MultiStreamWriter,
+    OutputFormat,
+    make_stream_writer,
+)
+
+NESTED_ROWS = [
+    {
+        "id": "m1",
+        "observation_type": "OBA:VT0001253",
+        "value_quantity": {"value_decimal": 155.448, "unit": "cm"},
+    },
+    {
+        "id": "m2",
+        "observation_type": "OBA:VT0001253",
+        "value_quantity": {"value_decimal": 167.386, "unit": "cm"},
+    },
+]
+
+
+def _write(rows: list[dict], target: Path, fmt: OutputFormat, **kwargs) -> None:
+    """Stream *rows* to *target* in *fmt* through the normal writer path."""
+    writer = make_stream_writer(fmt, **kwargs)
+    MultiStreamWriter([(writer, target)]).write_all(iter([rows]))
+
+
+@pytest.mark.parametrize(
+    ("extension", "expected"),
+    [(".parquet", OutputFormat.PARQUET), (".duckdb", OutputFormat.DUCKDB)],
+)
+def test_extension_maps_to_format(extension: str, expected: OutputFormat) -> None:
+    """A .parquet/.duckdb output path selects the columnar writer without an explicit flag."""
+    assert EXTENSION_FORMAT_MAP[extension] == expected
+
+
+def test_parquet_preserves_nesting_as_a_struct_column(tmp_path: Path) -> None:
+    """A nested object round-trips into Parquet as a STRUCT, readable by column access."""
+    target = tmp_path / "obs.parquet"
+    _write(NESTED_ROWS, target, OutputFormat.PARQUET)
+
+    con = duckdb.connect()
+    types = {r[0]: r[1] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{target}')").fetchall()}
+    assert types["value_quantity"] == "STRUCT(value_decimal DOUBLE, unit VARCHAR)"
+    rows = con.execute(
+        f"SELECT id, value_quantity.unit, value_quantity.value_decimal FROM read_parquet('{target}') ORDER BY id"
+    ).fetchall()
+    assert rows == [("m1", "cm", 155.448), ("m2", "cm", 167.386)]
+
+
+def test_parquet_target_holds_no_staging_file(tmp_path: Path) -> None:
+    """The staging JSONL is removed, leaving only the artifact."""
+    target = tmp_path / "obs.parquet"
+    _write(NESTED_ROWS, target, OutputFormat.PARQUET)
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["obs.parquet"]
+
+
+def test_duckdb_writes_a_queryable_table(tmp_path: Path) -> None:
+    """DuckDB output lands a table named for the file stem by default."""
+    target = tmp_path / "phs000000.duckdb"
+    _write(NESTED_ROWS, target, OutputFormat.DUCKDB)
+
+    con = duckdb.connect(str(target))
+    assert [r[0] for r in con.execute("SHOW TABLES").fetchall()] == ["phs000000"]
+    rows = con.execute('SELECT id, value_quantity.unit FROM "phs000000" ORDER BY id').fetchall()
+    assert rows == [("m1", "cm"), ("m2", "cm")]
+
+
+def test_duckdb_table_name_override(tmp_path: Path) -> None:
+    """--table-name controls the table, so several classes can share one database file."""
+    target = tmp_path / "phs000000.duckdb"
+    _write(NESTED_ROWS, target, OutputFormat.DUCKDB, table_name="measurement_observation")
+    con = duckdb.connect(str(target))
+    assert [r[0] for r in con.execute("SHOW TABLES").fetchall()] == ["measurement_observation"]
+
+
+def test_duckdb_accumulates_tables_across_runs(tmp_path: Path) -> None:
+    """Repeated runs against one file add tables rather than replacing the database.
+
+    This is how a per-study database covering several target classes gets built.
+    """
+    target = tmp_path / "phs000000.duckdb"
+    _write(NESTED_ROWS, target, OutputFormat.DUCKDB, table_name="measurement_observation")
+    _write([{"id": "p1", "sex": "F"}], target, OutputFormat.DUCKDB, table_name="participant")
+
+    con = duckdb.connect(str(target))
+    tables = sorted(r[0] for r in con.execute("SHOW TABLES").fetchall())
+    assert tables == ["measurement_observation", "participant"]
+    assert con.execute('SELECT count(*) FROM "measurement_observation"').fetchone() == (2,)
+
+
+def test_multivalued_nesting_becomes_a_struct_list(tmp_path: Path) -> None:
+    """A list of nested objects becomes STRUCT[], not a normalized side table."""
+    rows = [
+        {
+            "id": "s1",
+            "observations": [
+                {"id": "m1", "value": 1.5},
+                {"id": "m2", "value": 2.5},
+            ],
+        }
+    ]
+    target = tmp_path / "sets.parquet"
+    _write(rows, target, OutputFormat.PARQUET)
+
+    con = duckdb.connect()
+    types = {r[0]: r[1] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{target}')").fetchall()}
+    assert types["observations"] == 'STRUCT(id VARCHAR, "value" DOUBLE)[]'
+    assert con.execute(f"SELECT observations[1].id FROM read_parquet('{target}')").fetchone() == ("m1",)
+
+
+def test_empty_stream_writes_an_empty_artifact(tmp_path: Path) -> None:
+    """A transform yielding no rows still produces a readable file, not a crash."""
+    target = tmp_path / "empty.parquet"
+    _write([], target, OutputFormat.PARQUET)
+    con = duckdb.connect()
+    assert con.execute(f"SELECT count(*) FROM read_parquet('{target}')").fetchone() == (0,)
+
+
+def test_columnar_output_alongside_other_formats(tmp_path: Path) -> None:
+    """Parquet works as an additional -O target beside a text primary output."""
+    jsonl_target = tmp_path / "obs.jsonl"
+    parquet_target = tmp_path / "obs.parquet"
+    outputs = [
+        (make_stream_writer(OutputFormat.JSONL), jsonl_target),
+        (make_stream_writer(OutputFormat.PARQUET), parquet_target),
+    ]
+    MultiStreamWriter(outputs).write_all(iter([NESTED_ROWS]))
+
+    assert len(jsonl_target.read_text().strip().splitlines()) == 2
+    con = duckdb.connect()
+    assert con.execute(f"SELECT count(*) FROM read_parquet('{parquet_target}')").fetchone() == (2,)


### PR DESCRIPTION
Closes #325.

Transformed objects stream to a staging JSONL file, which DuckDB's `read_json_auto` then turns into the artifact. That inference is the point — it types each field on its own, so a nested object lands as a `STRUCT` column and a list of them as `STRUCT[]`:

```
value_quantity => STRUCT(value_decimal DOUBLE, unit VARCHAR)
observations   => STRUCT(id VARCHAR, "value" DOUBLE)[]
```

A consumer reads a nested field with a column access rather than a join, and linkml-map never has to describe the shape. Staging preserves the streaming contract: objects are never all held in memory, and the output path only ever contains the finished artifact.

```
linkml-map map-data -T transform.yaml -s schema.yaml --source-type Person \
  -o agents.parquet data/Person.tsv
```

Both formats work by extension and as `-O` targets alongside a text primary output. DuckDB output writes one table per run — named by `--table-name`, defaulting to the file stem — so repeated runs against one path build a database covering several target classes, which is the shape downstream consumers assemble by hand today.

`duckdb` was already a hard dependency (the join engine uses it), so this adds none.

### Why this rather than the SQL backend

#325 framed Parquet as work on `DuckDBTransformer`. It isn't: `SQLCompiler` supports almost none of the specification language — `expr`, `value`, `case()`, unit conversion and value mappings are all dropped silently — so nothing real transforms through it. The Python backend already produces correct nested output; only the serialization step was missing. See the closing comment on #332 for the full finding.

### Incidental refactor

`StreamWriter` gains two optional hooks, `staging_path` and `finalize_path`. The tabular header rewrite moves onto `finalize_path`, so `MultiStreamWriter` no longer type-checks for `TabularStreamWriter` to decide whether to post-process.