### PR TITLE
Document the columnar output formats; fix the mkdocs nav

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,13 +28,16 @@ interpreted by different execution backends:
 - **ObjectTransformer** (Python) — interprets the spec row-by-row, supports the full feature set
   including Python expressions, unit conversion, and cross-class lookups.
 - **SQLCompiler / DuckDBTransformer** (SQL) — compiles the spec to SQL for set-based execution.
-  This backend is **experimental** and supports a limited subset of the specification today.
-  See the [SQL Compilation tutorial](examples/Tutorial-SQLCompiler.ipynb) for current capabilities.
+  This backend is **experimental**, and the subset it supports is narrow: `expr`, `value`,
+  `case()`, unit conversion and value mappings are **dropped silently** rather than raising,
+  so a spec using any of them compiles to SQL that quietly omits those slots. Use the
+  ObjectTransformer unless you have verified your spec compiles faithfully. The
+  [SQL Compilation tutorial](examples/Tutorial-SQLCompiler.ipynb) shows the shape it does handle.
 
-The output serialization formats (YAML, JSON, JSONL, TSV, CSV) are intentionally limited to
-text-based representations of transformed data. For loading results into analytical stores
-(DuckDB, Parquet, databases), use the appropriate downstream tool — e.g., DuckDB's native
-`read_json()` or `read_csv()` functions work directly on linkml-map output files.
+Transformed data serializes to text (YAML, JSON, JSONL, TSV, CSV) or to a columnar
+artifact (Parquet, DuckDB). The columnar formats preserve nested structure that the
+flat text formats cannot: a nested object becomes a `STRUCT` column rather than being
+flattened away. See [Columnar Output](#columnar-output).
 
 This documentation is available at:
 
@@ -392,6 +395,8 @@ The `-f/--output-format` option supports:
 - `jsonl` - JSON Lines (one object per line)
 - `tsv` - Tab-separated values
 - `csv` - Comma-separated values
+- `parquet` - Apache Parquet, with nested fields preserved as columns
+- `duckdb` - a DuckDB database file, one table per run
 
 Output format can also be inferred from the output file extension.
 
@@ -427,7 +432,38 @@ linkml-map map-data \
 
 The primary output uses `-f`/`-o` as usual. Each `-O` flag adds an additional
 output file whose format is inferred from the file extension (`.json`, `.jsonl`,
-`.yaml`, `.yml`, `.tsv`, `.csv`). All outputs are written in a single streaming pass.
+`.yaml`, `.yml`, `.tsv`, `.csv`, `.parquet`, `.duckdb`). All outputs are written
+in a single streaming pass.
+
+#### Columnar Output
+
+`parquet` and `duckdb` write a columnar artifact rather than text. Unlike `tsv`
+and `csv`, which flatten to one row of scalars, these keep nested structure: a
+nested object becomes a `STRUCT` column and a list of them a `STRUCT[]`, so a
+consumer reads a nested field with a column access instead of a join.
+
+```bash
+linkml-map map-data \
+  -T transform.yaml \
+  -s schema.yaml \
+  --source-type Person \
+  -o agents.parquet \
+  data/Person.tsv
+```
+
+DuckDB output writes one table per run, named by `--table-name` and defaulting
+to the output file's stem. Pointing several runs at the same `.duckdb` path
+builds up a database covering multiple target classes:
+
+```bash
+linkml-map map-data -T transform.yaml -s schema.yaml \
+  --source-type Person --table-name person -o study.duckdb data/Person.tsv
+linkml-map map-data -T transform.yaml -s schema.yaml \
+  --source-type Measurement --table-name measurement -o study.duckdb data/Measurement.tsv
+```
+
+Both formats also work as `-O` targets alongside a text primary output. Neither
+adds a dependency: `duckdb` is already required by the join engine.
 
 ### derive-schema
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,12 +25,12 @@ markdown_extensions:
 nav:
   - Index: index.md
   - Examples:
-      Tutorial: examples/Tutorial.ipynb
-      Compilation to SQL: examples/Tutorial-SQLCompiler.ipynb
-      Metamodel Mapping: examples/MetamodelMapping.ipynb
+      - Tutorial: examples/Tutorial.ipynb
+      - Compilation to SQL: examples/Tutorial-SQLCompiler.ipynb
+      - Metamodel Mapping: examples/MetamodelMapping.ipynb
   - Specification:
-      Data Model: schema/datamodel.md
-      Compliance Suite: specification/compliance.md
+      - Data Model: schema/datamodel.md
+      - Compliance Suite: specification/compliance.md
   - API:
       - Session: api/session.md
       - Transformer: api/transformer.md


### PR DESCRIPTION
Light docs pass before the release, focused on where the docs are *wrong* rather than merely thin.

### Three passages contradicted the shipped CLI

Parquet and DuckDB (#333) landed undocumented, which left `index.md` actively misleading in three places:

1. The `-f/--output-format` list omitted `parquet` and `duckdb`.
2. The `-O` extension list omitted `.parquet` and `.duckdb`.
3. Worst of the three — the architecture section said output was **"intentionally limited to text-based representations"** and told readers to *"use the appropriate downstream tool"* for loading into DuckDB or Parquet. That now steers people away from the feature this release exists for.

Added a **Columnar Output** section covering the nested-`STRUCT` behaviour, `--table-name`, and accumulating several runs into one `.duckdb` file.

### Everything here was verified, not transcribed

I ran each documented command against `tests/input/examples/tabular` rather than paraphrasing #333's description:

- Parquet output — produced a real artifact
- Two runs at one `.duckdb` path with different `--table-name` values → `SHOW TABLES` returns `['person', 'person_csv']`, confirming accumulation
- The `STRUCT` claim is asserted by existing tests (`STRUCT(value_decimal DOUBLE, unit VARCHAR)`), so I cited behaviour that's already pinned
- "Adds no dependency" — `duckdb` was already required by the join engine

### SQL backend caveat sharpened

It was described as "experimental" with "a limited subset". The word that was missing is **silently**: `expr`, `value`, `case()`, unit conversion and value mappings are dropped without raising, so a spec using any of them compiles to SQL that quietly omits those slots. That's a correctness trap, not a feature gap, and it now says so.

### mkdocs nav

The `Examples` and `Specification` sections used YAML mappings where mkdocs wants lists, so `mkdocs build --strict` aborted on two config warnings before reaching any content checks. Pre-existing on main; fixed here since it's cheap and it makes strict builds usable.

### Not fixed here

With the nav corrected, strict mode surfaces **21 broken image links** in `docs/schema/overview.md` — references to `img/Mapping Between LinkML Schemas*.png` that have never existed in the repo. That file is generated by `make gendoc`, so the fix belongs in the generator or the source schema, not a docs edit. Filing separately. CI runs `mkdocs gh-deploy` without `--strict`, so this isn't newly broken — just newly visible.

Normal `mkdocs build` succeeds, as before.